### PR TITLE
Login popup fixes

### DIFF
--- a/src/globalComponents/getErrorFromObject.js
+++ b/src/globalComponents/getErrorFromObject.js
@@ -1,0 +1,23 @@
+//@flow strict
+
+type ErrorObject = {
+	msg?: string,
+	errors?: Array<GeneralError>
+}
+
+type GeneralError = {
+	msg?: string
+}
+//parses the object returned from the database and returns a string
+//describing the error of what went wrong
+function getErrorFromObject(errors: ErrorObject): string {
+	if (errors.msg != null) {
+		return errors.msg;
+	}
+	if (errors.errors != null && errors.errors.length>0) {
+		return errors.errors[0].msg;
+	}
+	return '';
+}
+
+export default getErrorFromObject;

--- a/src/globalComponents/getErrorFromObject.js
+++ b/src/globalComponents/getErrorFromObject.js
@@ -6,7 +6,7 @@ type ErrorObject = {
 }
 
 type GeneralError = {
-	msg?: string
+	msg: string
 }
 //parses the object returned from the database and returns a string
 //describing the error of what went wrong

--- a/src/login/Login.js
+++ b/src/login/Login.js
@@ -12,8 +12,8 @@ import Leaderboard from '../globalComponents/Leaderboard.js';
 // Main login page. Front-page of Fortuna.
 class Login extends React.Component<{||}> {
 
-	onEmailRegistered(registeredEmail: string, registeredPassword: string): void {
-		this.refs.loginPopup.onEmailRegistered(registeredEmail, registeredPassword);
+	onEmailRegistered(registeredUsername: string, registeredPassword: string): void {
+		this.refs.loginPopup.onEmailRegistered(registeredUsername, registeredPassword);
 	}
 
 	render(): React.Node {

--- a/src/login/LoginPopup.js
+++ b/src/login/LoginPopup.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import Popup from 'reactjs-popup';
 import Cookies from 'universal-cookie';
+import getErrorFromObject from '../globalComponents/getErrorFromObject.js';
 // Login component.
 
 type Props = {||}; 
@@ -51,7 +52,8 @@ class LoginPopup extends React.Component<Props, State> {
 				if (response.status !== 200) {
 					console.log(response.status);
 					console.log(data.msg);
-					this.setState({errorMessage: data.msg});
+					console.log(data);
+					this.setState({errorMessage: getErrorFromObject(data)});
 				}
 				else {
 					console.log(data);

--- a/src/login/LoginPopup.js
+++ b/src/login/LoginPopup.js
@@ -71,11 +71,12 @@ class LoginPopup extends React.Component<Props, State> {
 		this.setState({loginDialogOpen: false});
 	}
 
-	onEmailRegistered(registeredEmail: string, registeredPassword: string) {
+	onEmailRegistered(registeredUsername: string, registeredPassword: string) {
 		this.setState({
-			userName: registeredEmail,
+			userName: registeredUsername,
 			password: registeredPassword,
-			loginDialogOpen: true
+			loginDialogOpen: true,
+			errorMessage: 'Please click the link we set to your email and the log in.'
 		});
 	}
 
@@ -94,7 +95,10 @@ class LoginPopup extends React.Component<Props, State> {
 				<button type="button" className="primarybtn" onClick={() => this.setState({loginDialogOpen: true})}>
 					Login
 				</button>
-				<Popup open={this.state.loginDialogOpen}>
+				<Popup 
+					open={this.state.loginDialogOpen}
+					onClose={() => this.handleCancelClick()}
+				>
 					<div className="popup">
 						<h3>Login</h3>
 						<div className="row col-md-12">

--- a/src/login/SignupPopup.js
+++ b/src/login/SignupPopup.js
@@ -1,6 +1,7 @@
 //@flow strict
 import * as React from 'react';
 import Popup from 'reactjs-popup';
+import getErrorFromObject from '../globalComponents/getErrorFromObject.js';
 
 type Props = {|
 	onEmailRegisteredCallback: (string, string) => void
@@ -59,7 +60,8 @@ class SignupPopup extends React.Component<Props, State> {
 				if (response.status !== 201) {
 					console.log(response.status);
 					console.log(data.msg);
-					this.setState({errorMessage: data.msg});
+					console.log(data);
+					this.setState({errorMessage: getErrorFromObject(data)});
 				}
 				else {
 					console.log(data);

--- a/src/login/SignupPopup.js
+++ b/src/login/SignupPopup.js
@@ -63,7 +63,7 @@ class SignupPopup extends React.Component<Props, State> {
 				}
 				else {
 					console.log(data);
-					this.props.onEmailRegisteredCallback(this.state.email, this.state.password);
+					this.props.onEmailRegisteredCallback(this.state.userName, this.state.password);
 					this.setState({signupDialogOpen: false});
 				}
 			})
@@ -85,7 +85,10 @@ class SignupPopup extends React.Component<Props, State> {
 				<button type="button" className="clearbtn" onClick={() => this.setState({signupDialogOpen: true})}>
 					Signup
 				</button>
-				<Popup open={this.state.signupDialogOpen}>
+				<Popup 
+					open={this.state.signupDialogOpen}
+					onClose={() => this.handleCancelClick()}
+				>
 					<div className="popup">
 						<h3>Signup</h3>
 						<div className="row col-md-12">


### PR DESCRIPTION
**Description**
Allows the login/signup popups to be closed by clicking outside of them and reopened later (thanks Emil for finding that bug). Upon further inspection, Casus doesn't actually need to be changed since filling out the form is mandatory unless you hit cancel. Also properly handles error messages when an array of errors is returned from the backend.


Resolves #142

**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
- Passes flow with no errors.
- Gives errors on the front end when:
    - username too short
    - password too short
    - email not valid
    - passwords don't match (verified on front-end)

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.