### PR TITLE
Tiny: Lint error on order of types

### DIFF
--- a/src/globalComponents/getErrorFromObject.js
+++ b/src/globalComponents/getErrorFromObject.js
@@ -1,13 +1,14 @@
 //@flow strict
 
+type GeneralError = {
+	msg: string
+}
+
 type ErrorObject = {
 	msg?: string,
 	errors?: Array<GeneralError>
 }
 
-type GeneralError = {
-	msg: string
-}
 //parses the object returned from the database and returns a string
 //describing the error of what went wrong
 function getErrorFromObject(errors: ErrorObject): string {


### PR DESCRIPTION
**Description**
Fixes a lint warning I just caused on having my types in the wrong order.

**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.

**Final Checklist:**
Go down the list and check them off.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design document (if applicable)
- [ ] My changes generate no new warnings
- [ ] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.