### PR TITLE
Created Separate getTankMarketSales route to get tanks and enable getting their names

### DIFF
--- a/src/backend/controllers/marketController.js
+++ b/src/backend/controllers/marketController.js
@@ -241,6 +241,50 @@ exports.getMarketSales = async (req: Request, res: Response) => {
     }
 }
 
+// Gets all Tank Marketplace Sales not belonging to the user
+exports.getTankMarketSales = async (req: Request, res: Response) => {
+    // Validation
+    const errors = validationResult(req);
+
+    if (!errors.isEmpty()) {
+        // Return 400 for a bad request
+        return res
+            .status(400)
+            .json({ errors: errors.array() });
+    }
+
+    // Deconstruct userId from parameter
+    const { userId } = req.params;
+
+    try {
+        // Check if valid user
+        const user = await User.findById(userId);
+        if (!user) {
+            return res
+                .status(400)
+                .json({ msg: 'User does not exist' });
+        }
+
+        // Get list of tank sales from DB that do not belong to logged in user
+        const salesList = await MarketSale.find({ sellerId: { $ne: userId }, itemType: { $eq: 'tank' } })
+            .populate('itemId', 'tankName');
+        if (!salesList) {
+            return res
+                .status(400)
+                .json({ msg: 'Unable to get list of Tank Market Sales.' });
+        }
+
+        // Return list of sales
+        console.log('Retrieved Tank Market Sale List.');
+        return res.status(200).json(salesList);
+
+    }
+    catch (err) {
+        console.error(err.message);
+        return res.status(500).json({ msg: 'Unable to find list of Tank Sales.' });
+    }
+}
+
 // Gets a single Marketplace Sale
 exports.getMarketSale = async (req: Request, res: Response) => {
     try {

--- a/src/backend/routes/marketRoutes.js
+++ b/src/backend/routes/marketRoutes.js
@@ -35,12 +35,22 @@ router.post('/addMarketSale', [
 // Get the list of all Market Sales
 // Route call: getMarketSales
 // Req needs userId
-// Returns list of all Market Sales or an error
+// Returns list of all Market Sales not belonging to the user or an error
 // Check messages can be edited
 router.get('/getMarketSales/:userId', [
     check('userId', 'userId is required')
         .isString()
 ], marketController.getMarketSales);
+
+// Get the list of all Market Sales
+// Route call: getTankMarketSales
+// Req needs userId
+// Returns list of all Tank Market Sales not belonging to the user or an error
+// Check messages can be edited
+router.get('/getTankMarketSales/:userId', [
+    check('userId', 'userId is required')
+        .isString()
+], marketController.getTankMarketSales);
 
 // Get a single market sale by ID
 // Route call: getMarketSale

--- a/src/models/marketSaleModel.js
+++ b/src/models/marketSaleModel.js
@@ -27,7 +27,8 @@ const MarketSale = new Mongoose.model('MarketplaceSale', new Mongoose.Schema({
     // or a String description of the type of component or casus block.
     itemId: {
         type: String,
-        required: true
+        required: true,
+        ref: 'Tank'
     },
     // Enum item category required on creation.
     itemType: {


### PR DESCRIPTION
**Description**
Created a new route called /api/marketplace/getTankMarketSales
* Takes in a userId in the path (so it's like  `/api/marketplace/getTankMarketSales/:userId`)
* Searches the DB for all tank sales that aren't associated with the user.
* The array of market sales for tanks look like the following picture, enabling access to their names: 
![image](https://user-images.githubusercontent.com/24559442/77244686-3a234580-6bee-11ea-88d1-3329375228f2.png)
* Also doesn't interfere with how the normal getMarketSales route works when it comes to utilizing the `itemId` field for component names vs. tank ObjectIds: 
![image](https://user-images.githubusercontent.com/24559442/77244880-84a5c180-6bf0-11ea-9ac2-89ad8c9d9dc5.png)

Marketplace front-end that retrieves tank sales would have to use this route instead of the getMarketSales route.

Resolves #227 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
Assuming you checked out branch:
1. `npm run build && npm run devserver` and `npm start` on another terminal
2. Log on to Fortuna and make a tank (User A)
3. Put the tank on sale.
4. Open up Postman and use the GET route `localhost:3001/api/marketplace/getTankMarketSales/putUserB'sObjectIdHere`
5. Confirm list of tanks on sale are formatted like the picture in description.

**Final Checklist:**
Go down the list and check them off.

Passes Flow:
![image](https://user-images.githubusercontent.com/24559442/77244778-86bb5080-6bef-11ea-83ce-f265772d98eb.png)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.