### PR TITLE
Implemented API to Delete Tanks

### DIFF
--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -145,6 +145,28 @@ exports.deleteTank = async (req: Request, res: Response) => {
 		return res.status(400).json({ msg: 'Could not find tank in DB' });
 	}
 
+	// Add components back to user inventory
+	let user = await User.findById({ _id: tank.userId });
+	if (!user) {
+		console.error('User for tank not found');
+		return res.status(500).json({ msg: 'Owner of tank not found' });
+	}
+
+	for (const component of tank.components) {
+		if (component === null) {
+			continue;
+		}
+		user['inventory']['tankComponents'][component] += 1;
+	}
+
+	// Save the user
+	await user.save((err: Error) => {
+		if (err) {
+			console.error('Could not update user inventory.');
+			return res.status(500).json('Could not update user inventory.');
+		}
+	});
+
 	// Delete tank
 	await Tank.deleteOne({ _id: tank._id }, (err: Error) => {
 		if (err) {

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -123,5 +123,35 @@ exports.casusUpdate = async (req: Request, res: Response) => {
 		res.status(200).send(tank);
 		console.log('Successfully updated tank Casus code.')
 	});
+}
 
+exports.deleteTank = async (req: Request, res: Response) => {
+	//check if all the fields are input correctly from the frontend
+	const errors = validationResult(req);
+
+	if(!errors.isEmpty()){
+		// 400 is a bad request
+		return res
+			.status(400)
+			.json({ errors: errors.array() });
+	}
+
+	// Deconstruct request
+	const { tankId } = req.params;
+
+	const tank = await Tank.findById(tankId);
+	if (!tank) {
+		console.error('Tank not in DB');
+		return res.status(400).json({ msg: 'Could not find tank in DB' });
+	}
+
+	// Delete tank
+	await Tank.deleteOne({ _id: tank._id }, (err: Error) => {
+		if (err) {
+			console.error(err.message);
+			return res.status(500).json({ msg: 'Could not delete tank from DB' });
+		}
+	});
+	
+	return res.status(200).json({ msg: 'Successfully deleted Tank' });
 }

--- a/src/backend/routes/tankRoutes.js
+++ b/src/backend/routes/tankRoutes.js
@@ -58,6 +58,10 @@ router.put('/casusUpdate/:tankId', [
         .exists(),
     ], tankController.casusUpdate);
 
+// Deletes tank from DB
+// Route Call: /deleteTank/<tankId>
+// Req must contain the tankId within the uri of the api call in place of <tankId>
+// Returns confirmation message that tank was deleted.
 router.delete('/deleteTank/:tankId', [
     check('tankId', 'tankId should be a MongoId string')
         .isMongoId()

--- a/src/backend/routes/tankRoutes.js
+++ b/src/backend/routes/tankRoutes.js
@@ -35,7 +35,6 @@ router.get('/userTanks', auth, tankController.userTanks);
 // Returns the id of the new tank
 router.post('/assignTank', auth, tankController.assignTank);
 
-
 // Updates the entire document of the tank
 // Route Call: /tankUpdate/<tankId>
 // Req must contain the tankId within the uri of the api call in place of <tankId>
@@ -58,5 +57,10 @@ router.put('/casusUpdate/:tankId', [
     check('casusCode', 'casusCode is required')
         .exists(),
     ], tankController.casusUpdate);
+
+router.delete('/deleteTank/:tankId', [
+    check('tankId', 'tankId should be a MongoId string')
+        .isMongoId()
+    ], tankController.deleteTank);
 
 module.exports = router;


### PR DESCRIPTION
**Description**
Implemented API to delete tanks.
As stated in the issue:
* Takes in tankId in the API path
* Deletes tank in DB with that tankId
* Returns a 200 status with a confirmation message if front-end wishes to use it.

Resolves #234 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
1. Login and make a tank
2. Get that tankId from MongoDB Compass
3. Use the deleteTank route in Postman (`/api/tank/deleteTank/tankIdGoesHere`)
4. Confirm confirmation message and Tank deleted in MongoDB Compass.

**Final Checklist:**
Go down the list and check them off.

Passes Flow:
![image](https://user-images.githubusercontent.com/24559442/77267124-fb39d200-6c77-11ea-9aab-0b006191e0bb.png)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.