### PR TITLE
Removed setState in constructors

### DIFF
--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -88,6 +88,9 @@ class Armory extends React.Component<Props, State> {
 		if (this.state.selectedTank == null) {
 			throw new Error('Failed in loading blank tank!');
 		}
+	}
+
+	componentDidMount(): void {
 		// Functions to get all user tanks and user inventory.
 		this.getTanks();
 		this.getUserInventory();
@@ -95,7 +98,7 @@ class Armory extends React.Component<Props, State> {
 
 	// Gets all user tanks and sets them to the state.
 	getTanks(): void {
-		const responsePromise = getAllUsersTanks();
+		const responsePromise: Promise<Response> = getAllUsersTanks();
 		
 		responsePromise.then (
 			response => response.json().then(data => {

--- a/src/armory/CreateNewTankPopup.js
+++ b/src/armory/CreateNewTankPopup.js
@@ -35,14 +35,11 @@ class CreateNewTankPopup extends React.Component<Props, State> {
 			errorMessage: '',
 			newTankDialogOpen: false,
 		}
-
-		// Get the user ID for when a new tank is created.
-		this.getUserId();
     }
 
-	getUserId(): void {
+	// Once mounted, set the userId.
+	componentDidMount(): void {
 		const responsePromise = getUser();
-
 		responsePromise.then (
 			response => response.json().then(data => {
 				if(response.status !== 200) {

--- a/src/globalComponents/Navbar.js
+++ b/src/globalComponents/Navbar.js
@@ -49,29 +49,6 @@ class Navbar extends React.Component<Props, State> {
 
 	// Once mounted, set the cookie to store user's name and money.
 	componentDidMount(): void {
-		this.setCookie();
-	}
-
-	// Check if the back button will logout the user.
-	handleLogout(): void {
-
-		// If the user isn't logging out, leave this function.
-		if(this.props.returnName !== 'Logout') {
-			return;
-		}
-
-		// Delete All cookies. 
-		const cookie = new Cookies();
-		for(let cookieName of Object.keys(cookie.getAll())) {
-			cookie.remove(cookieName);
-		}
-
-		window.location = verifyLink('/Login');
-	}
-
-	// Set user's name and money in the state and in a cookie.
-	setCookie(): void {
-		
 		// Set the cookie and update state.
 		const cookies = new Cookies();
 		const token = cookies.get('token');
@@ -97,6 +74,23 @@ class Navbar extends React.Component<Props, State> {
 				}
 			})
 		)
+	}
+
+	// Check if the back button will logout the user.
+	handleLogout(): void {
+
+		// If the user isn't logging out, leave this function.
+		if(this.props.returnName !== 'Logout') {
+			return;
+		}
+
+		// Delete All cookies. 
+		const cookie = new Cookies();
+		for(let cookieName of Object.keys(cookie.getAll())) {
+			cookie.remove(cookieName);
+		}
+
+		window.location = verifyLink('/Login');
 	}
 
 	render(): React.Node {


### PR DESCRIPTION
**Description**
Small change that moves any setState calls into componentDidMount. This is only recommended when the setState calls are in a fetch. Otherwise, do not put setState into componentDidMount.

More research needs to be done on this, but I don't think it is super important for right now. We will have to deal with the duplicate code.

**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
View code to see changes.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.