### PR TITLE
Added logic to prevent deletion of final tank.

### DIFF
--- a/src/backend/controllers/marketController.js
+++ b/src/backend/controllers/marketController.js
@@ -44,6 +44,19 @@ exports.addMarketSale = async (req: Request, res: Response) => {
                     .json({ msg: 'Tank does not exist under this user.' });
             }
 
+            // Check if this the only tank left for the user
+            const tankList = await Tank.find({ userId: sellerId });
+            if (!tankList) {
+                console.error('Could not get list of user tanks.');
+                return res.status(500).json({ msg: 'Could not find list of user tanks.' });
+            }
+
+            // tankList is an array of the objects, so you can access the length property
+            if (tankList.length === 1) {
+                console.error('This is the last tank of the user.');
+                return res.status(500).json({ msg: 'You cannot delete your last tank.' });
+            }
+
             // Make a new Marketplace Sale
             // if tank exists
             const sale = new MarketSale({

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -280,6 +280,18 @@ exports.deleteTank = async (req: Request, res: Response) => {
 		return res.status(400).json({ msg: 'Could not find tank in DB' });
 	}
 
+	// Check if this the only tank left for the user
+	const tankList = await Tank.find({ userId: tank.userId });
+	if (!tankList) {
+		console.error('Could not get list of user tanks.');
+		return res.status(500).json({ msg: 'Could not find list of user tanks.' });
+	}
+
+	if (tankList.length === 1) {
+		console.error('This is the last tank of the user.');
+		return res.status(500).json({ msg: 'You cannot delete your last tank.' });
+	}
+
 	// Add components back to user inventory
 	let user = await User.findById({ _id: tank.userId });
 	if (!user) {

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -287,6 +287,7 @@ exports.deleteTank = async (req: Request, res: Response) => {
 		return res.status(500).json({ msg: 'Could not find list of user tanks.' });
 	}
 
+	// tankList is an array of the objects, so you can access the length property
 	if (tankList.length === 1) {
 		console.error('This is the last tank of the user.');
 		return res.status(500).json({ msg: 'You cannot delete your last tank.' });


### PR DESCRIPTION
**Description**
Made backend logic blocking users from deleting their last tank. Essentially the user's id from the tank they are proposing to delete is used to query to get an array of all tanks they own. If this tank is the last one on the array (i.e. the array of tanks length is 1), a 500 error is sent back with a message telling that you can't delete your last tank.

Resolves #281 

**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
1. Register and verify a user.
2. Log in to user and try to delete the starter tank from the armory.
3. You should not be able to delete it.

**Final Checklist:**
Go down the list and check them off.
Passes Flow:
![image](https://user-images.githubusercontent.com/24559442/77844785-59cee680-7177-11ea-8317-a98594d53726.png)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.