### PR TITLE
Hardcode training bot ids in training arena

### DIFF
--- a/src/trainingarena/TrainingArena.js
+++ b/src/trainingarena/TrainingArena.js
@@ -8,6 +8,26 @@ import { verifyLink } from '../globalComponents/verifyLink.js';
 import { verifyLogin } from '../globalComponents/verifyLogin.js';
 import setReturnToFromBattlegroundLink from '../battleground/setReturnToFromBattlegroundLink.js';
 
+type TrainingTankInfo = {
+	tankDisplayName: string,
+	tankID: string,
+}
+
+const HARDCODED_TRAINING_TANKS: Array<TrainingTankInfo> = [
+	{
+		tankDisplayName: 'Sitting Duck',
+		tankID: '5e7e8e1659a651503e14d7d1',
+	},
+	{
+		tankDisplayName: 'Roomba',
+		tankID: '5e7e8ece59a651503e14d7d2',
+	},
+	{
+		tankDisplayName: 'Rando Tank',
+		tankID: '5e7e8f2959a651503e14d7d3',
+	},
+];
+
 class TrainingArena extends React.Component<{||}> {
 
 	constructor() {
@@ -17,6 +37,9 @@ class TrainingArena extends React.Component<{||}> {
 
 	onClickStartBattle(): void {
 		setReturnToFromBattlegroundLink('/TrainingArena');
+		const trainingBotSelect: HTMLSelectElement=this.refs.trainingBotSelect;
+		const chosenBot=HARDCODED_TRAINING_TANKS.find(t => t.tankDisplayName === trainingBotSelect.value);
+		//TODO: start battle between chosen bot.tankID and the bot that I select
 		window.location.href=verifyLink('/Battleground');
 	}
 
@@ -59,11 +82,10 @@ class TrainingArena extends React.Component<{||}> {
 				</div>
 				<div className="column taright">
 					<h5>Choose a Training Bot</h5>
-					<select className="dropdownMenu">
-						<option defaultValue>Select a Tank</option>
-						<option value="1">Child Consumer</option>
-						<option value="2">Fast Bang</option>
-						<option value="3">Biggest Gun</option>
+					<select className="dropdownMenu" ref="trainingBotSelect">
+						{HARDCODED_TRAINING_TANKS.map(trainingTankInfo =>
+							<option key= {trainingTankInfo.tankID}>{trainingTankInfo.tankDisplayName}</option>
+						)}
 					</select>
 				</div>
 			</div>


### PR DESCRIPTION
**Description**
This PR hardcodes the training bot ids in the training arena so that we can later start battles against those training bots. Currently they aren't actually used for anything, but when we hook up training arena and battle arena to everything else, they will be.

Resolves #290

**Type of change**
Check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
Not really testable with the UI at the moment. This select works correctly:
![image](https://user-images.githubusercontent.com/18317476/77854475-97a02f00-71b8-11ea-8a58-edcae0371c4b.png)

And if you print the id of the tank that is selected when you click start, it matches what is in the DB.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.