### PR TITLE
Centered battleground and made it higher definition

### DIFF
--- a/src/battleground/Battleground.css
+++ b/src/battleground/Battleground.css
@@ -1,4 +1,4 @@
 .battlegroundCanvas {
 	background-color: #fafafa;
-	width: 100%
+	width: 1300px; 
 }

--- a/src/battleground/Battleground.js
+++ b/src/battleground/Battleground.js
@@ -218,7 +218,7 @@ class Battleground extends React.Component<Props> {
 	_resizeCanvas(): void {
 		const canvas: HTMLCanvasElement = this.refs.canvas;
 		const targetWidth=canvas.clientWidth;
-		const targetHeight=targetWidth*8/16;
+		const targetHeight=targetWidth/200*120;
 		if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
 			canvas.width = targetWidth;
 			canvas.height = targetHeight;

--- a/src/battleground/BattlegroundContainer.css
+++ b/src/battleground/BattlegroundContainer.css
@@ -1,0 +1,7 @@
+.battlegroundContainer {
+	width: 1300px;
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+
+}

--- a/src/battleground/BattlegroundContainer.js
+++ b/src/battleground/BattlegroundContainer.js
@@ -6,6 +6,8 @@ import HealthBarsField from './HealthBarsField.js';
 import Navbar from '../globalComponents/Navbar.js';
 import Tank from '../tanks/Tank.js';
 
+import './BattlegroundContainer.css';
+
 type Props = {||};
 
 type State = {
@@ -25,19 +27,21 @@ class BattlegroundContainer extends React.Component<Props, State> {
 
 	render(): React.Node {
 		return (
-			<div className="haveScorebarIfSmall">
+			<div>
 				<Navbar
 					linkName='/BattleArena'
 					returnName='Back to Battle Arena'
 					pageName='Battleground'
 				/>
-				<HealthBarsField
-					playerOneTank = {this.state.playerOneTank}
-					playerTwoTank = {this.state.playerTwoTank}
-				/>
-				<Battleground 
-					setPlayersTank = {this.setPlayersTank}
-				/>
+				<div className="battlegroundContainer">
+					<HealthBarsField
+						playerOneTank = {this.state.playerOneTank}
+						playerTwoTank = {this.state.playerTwoTank}
+					/>
+					<Battleground 
+						setPlayersTank = {this.setPlayersTank}
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/src/battleground/HealthBar.css
+++ b/src/battleground/HealthBar.css
@@ -1,0 +1,4 @@
+.healthBarCanvas {
+	height: 50px;
+	width: 400px;
+}

--- a/src/battleground/HealthBar.js
+++ b/src/battleground/HealthBar.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import Tank from '../tanks/Tank.js';
+import './HealthBar.css'
 
 type Props = {
 	playersTank: ?Tank,
@@ -20,7 +21,7 @@ class HealthBar extends React.Component<Props> {
 			const ctx = canvas.getContext("2d");
 			ctx.clearRect(0, 0, canvas.width, canvas.height);
 			ctx.fillStyle="#FF0000";
-			ctx.fillRect(10,140,currentHealth,25);
+			ctx.fillRect(10, 110,currentHealth,25);
 		}
 	}
 

--- a/src/battleground/getBattlegroundWidth.js
+++ b/src/battleground/getBattlegroundWidth.js
@@ -1,7 +1,7 @@
 //@flow strict
 
 function getBattlegroundWidth(): number {
-	return 900;
+	return 1300;
 }
 
 export default getBattlegroundWidth;


### PR DESCRIPTION
**Description**
The battleground is now centered with CSS and is 1300 px wide instead of the previous 900. We can easily change it if that is too wide, but I think on most displays this will look better.

Resolves #237

**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.