### PR TITLE
Update tank display when new scanner selected

### DIFF
--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -279,6 +279,19 @@ class Armory extends React.Component<Props, State> {
 				break;
 		}
 
+		//if the part index was a scanner add-on, we have to rebuild the scanner
+		if (partIndex===4 || partIndex===5) {
+			const scannerType=this.state.selectedTank.scanner.name;
+			console.log('Scanner type: '+scannerType);
+			const newScanner=new Scanner(
+					scannerType, 
+					(updatedTank.scannerAddonOne.name === 'itemScanner' || updatedTank.scannerAddonTwo.name === 'itemScanner') ? true : false,
+					(updatedTank.scannerAddonOne.name === 'antiJammerScanner' || updatedTank.scannerAddonTwo.name === 'antiJammerScanner') ? true : false,
+				);
+			updatedTank.scanner = newScanner;
+			console.log(newScanner.name);
+		}
+
 		// Update the component, points, and parts array.
 		this.updatePoints(newComponent.name, updatedTank.parts[partIndex].name);
 		updatedTank.parts[partIndex] = newComponent;

--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -282,14 +282,12 @@ class Armory extends React.Component<Props, State> {
 		//if the part index was a scanner add-on, we have to rebuild the scanner
 		if (partIndex===4 || partIndex===5) {
 			const scannerType=this.state.selectedTank.scanner.name;
-			console.log('Scanner type: '+scannerType);
 			const newScanner=new Scanner(
 					scannerType, 
 					(updatedTank.scannerAddonOne.name === 'itemScanner' || updatedTank.scannerAddonTwo.name === 'itemScanner') ? true : false,
 					(updatedTank.scannerAddonOne.name === 'antiJammerScanner' || updatedTank.scannerAddonTwo.name === 'antiJammerScanner') ? true : false,
 				);
 			updatedTank.scanner = newScanner;
-			console.log(newScanner.name);
 		}
 
 		// Update the component, points, and parts array.


### PR DESCRIPTION
**Description**
Previously the armory was updating the tankParts of the tank, but it wasn't creating a new scanner when the add ons to a scanner were changed. This was causing the scanner to render incorrectly when part of it was updated. This PR fixes that.

Resolves #322 
**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
Here is a gif of it working as expected:
![FixedScannerUpdatingInArmory](https://user-images.githubusercontent.com/18317476/77862202-e4e7c500-71e7-11ea-99d2-7ae2df2fb95c.gif)


**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.