### PR TITLE
Fixed incorrect references for SetWagerPopup

### DIFF
--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -37,7 +37,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 	// Once mounted, get the user's currency, wager, and favorite tank.
 	componentDidMount(): void {
 		getUserAPICall(user => {
-			this.setState({userCurrency: user.money, userWager: user.wager});
+			this.setState({userCurrency: user.money, currentWager: user.wager});
 		});
 
 		getFavoriteTank(tank => {
@@ -111,7 +111,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 					<div className="wagerTank">
 						{this.state.currentWagerTank.tankName + ' '} 
 						<label>
-							for {this.state.userWager}
+							for {this.state.currentWager}
 						</label>
 					</div>
 				}</label>


### PR DESCRIPTION
**Description**
Fixed the wager in the bottom left changing when a user was typing in the popup for a new wager.

Resolves #329 

**Type of change**
Check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a update in the design document

**Steps to Verify Functionality**
1. Go to Armory.
2. Set a wager if one isn't already set.
3. Click the Setup wager button.
4. Type in the input box, and view that the wager doesn't change at the bottom left.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the design document (if applicable)
- [x] My changes generate no new warnings
- [x] Pulled updated master branch (if changed since branch creation) and corrected any conflicts, if any occur.