### PR TITLE
Leaderboard route gets users with exception to master account.

### DIFF
--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -21,6 +21,7 @@ const MarketSale = require('../../models/marketSaleModel');
 const jwtSecret = process.env.JWT_SECRET;
 // Front-End Host Constant
 const FRONTEND = (process.env.NODE_ENV === 'development') ? 'localhost:3000' : 'fortunacombat.com';
+const MASTER_ID = process.env.MASTER_SELLER;
 
 exports.register = async (req: Request, res: Response) => {
 	// Creates a place where errors that fail validation can accrue.
@@ -437,7 +438,7 @@ exports.retrieveUser  = async (req: Request, res: Response) => {
 exports.getLeaders = async (req: Request, res: Response) => {
 	// skip and limit determine how many to return
 	// the -1 in the sort is for descending order based on elo
-	await User.find({}, ['userName', 'stats.elo'], { skip: 0, limit: 10, sort:{'stats.elo': -1} }, function(err: Error, leaders: Array<User>){
+	await User.find({ _id: { $ne: MASTER_ID } }, ['userName', 'stats.elo'], { skip: 0, limit: 10, sort:{'stats.elo': -1} }, function(err: Error, leaders: Array<User>){
 		if(err){
 			res.send(err);
 			console.error(err.message);


### PR DESCRIPTION
**Description**
Leaderboard API finds all users except the master account and returns the top 10. Whether or not there are less than or equal to 10 users in existence, the master account is not shown in the result.

**Resolves These Issues**
Resolves #349 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Have less than or equal to 10 users in the DB, including master account.
2. Run fortuna locally (`npm run devserver` and `npm start`)
3. Note that the master account is not present in the leaderboard.
4. *(Optional) Verify it as well on Postman and see what is returned. (The way I personally tested it.)

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [x] This change requires a update in the design document (if applicable)