### PR TITLE
Malformed JWT error no longer shows up unnecessarily

### DIFF
--- a/src/globalComponents/apiCalls/verifyLogin.js
+++ b/src/globalComponents/apiCalls/verifyLogin.js
@@ -4,6 +4,12 @@ import { verifyLink } from '../verifyLink.js';
 import getLoginToken from '../getLoginToken.js';
 
 function verifyLogin(): void {
+	// If the no user has logged in, then do not verify the login.
+	if(getLoginToken() == null) {
+		return;
+	}
+
+	// Otherwise, check if the login token is valid.
 	const responsePromise: Promise<Response> = fetch('/api/verify', {
 		method: 'GET',
 		headers: {

--- a/src/globalComponents/apiCalls/verifyLogin.js
+++ b/src/globalComponents/apiCalls/verifyLogin.js
@@ -4,8 +4,8 @@ import { verifyLink } from '../verifyLink.js';
 import getLoginToken from '../getLoginToken.js';
 
 function verifyLogin(): void {
-	// If the no user has logged in, then do not verify the login.
-	if(getLoginToken() == null) {
+	// If the use is on the login page and the token is null, do not check the token.
+	if(getLoginToken() == null && (window.location.pathname === '/Login' || window.location.pathname === '/')) {
 		return;
 	}
 


### PR DESCRIPTION
**Description**
Added a function that checks if the page is login and if getLoginToken is undefined (meaning no one has logged in), if so, then it does not perform the verify API call. This prevents the Malformed JWT error.

**Resolves These Issues**
Resolves #251 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to login.
2. Check devserver to see no errors show.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)