### PR TITLE
Casus Recolor Built in Variables and Prompt previously used Variables

### DIFF
--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -100,6 +100,10 @@ class Armory extends React.Component<Props, State> {
 	getTanks(): void {
 		getAllUsersTanks((successful, allTanks) => {
 			if (successful) {
+				if (allTanks.length === 0) {
+					console.log('Expected to have at least one tank!');
+					return;
+				}
 				// Always set the default selected tank to the newest tank.
 				const newSelectedTank = allTanks[allTanks.length-1];
 				setTankForCasus(newSelectedTank._id);

--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -13,6 +13,8 @@ import './CasusEditor.css';
 import saveCasus from './saveCasus.js';
 import loadCasus from './loadCasus.js';
 
+import type {DataType} from './blocks/DataType.js';
+
 type Props = {|
 	draggedBlocks: ?Array<CasusBlock>,
 	onDraggedBlocksReleased: () => void,
@@ -95,6 +97,7 @@ class CasusEditor extends React.Component<Props, State> {
 					variableBlockToRename={this.state.variableBlockToRename}
 					onCancelClicked={() => this.onCancelClicked()}
 					onVariableCreated={(created: string) => this.onVariableCreated(created)}
+					getExistingVariableNames={(dataType) => this._getExistingVariableNames(dataType)}
 				/>
 			</div>
 		);
@@ -239,6 +242,10 @@ class CasusEditor extends React.Component<Props, State> {
 			canvas.width=canvas.clientWidth;
 			canvas.height=canvas.clientHeight;
 		}
+	}
+
+	_getExistingVariableNames(dataType: DataType) {
+		return this.state.containerBlock.getExistingVariableNames(dataType);
 	}
 
 	//checks if a realeased block would be placed on an empty block with void return type

--- a/src/casus/blocks/CasusBlock.js
+++ b/src/casus/blocks/CasusBlock.js
@@ -110,6 +110,19 @@ class CasusBlock {
 		return this.boundingBox.contains(v) ? this : null;
 	}
 
+	getExistingVariableNames(dataType: DataType): Array<string> {
+		const allVariables=[];
+		for (const child of this.getChildBlocks()) {
+			const childVariables=child.getExistingVariableNames(dataType);
+			for (const varName of childVariables) {
+				if (!allVariables.includes(varName)) {
+					allVariables.push(varName);
+				}
+			}
+		}
+		return allVariables;
+	}
+
 	//returns true if we were able to place it in some container, false otherwise
 	tryToPlaceInContainer(
 		v: Vec, 

--- a/src/casus/blocks/GetVariableBlock.js
+++ b/src/casus/blocks/GetVariableBlock.js
@@ -8,7 +8,11 @@ import generateCornerPerim from './generateCornerPerim.js';
 import {getInterpriterState} from '../interpreter/InterpriterState.js';
 import InterpriterState from '../interpreter/InterpriterState.js';
 import type {Value} from '../interpreter/Value.js';
-import {isLegalConstant, getNameAsConstant} from '../userInteraction/defaultVariableNames.js';
+import {
+	isLegalConstant, 
+	getNameAsConstant, 
+	isBuiltInVariable
+} from '../userInteraction/defaultVariableNames.js';
 
 import {
 	RAMP_WIDTH, 
@@ -63,7 +67,17 @@ class GetVariableBlock extends CasusBlock {
 	}
 
 	drawSelf(ctx: CanvasRenderingContext2D): void {
-		ctx.fillStyle = '#ff00cb';
+		const builtInVariable = isBuiltInVariable(this.variableName, this.dataType);
+		const legalConstant = isLegalConstant(this.variableName, this.dataType);
+		if (builtInVariable) {
+			ctx.fillStyle = '#3dc2dc';
+		}
+		else if (legalConstant) {
+			ctx.fillStyle = '#aaaaaa';
+		}
+		else {
+			ctx.fillStyle = '#ff00cb';
+		}
 
 		const perim: Array<Vec> = this.getPerim();
 		ctx.beginPath();

--- a/src/casus/blocks/GetVariableBlock.js
+++ b/src/casus/blocks/GetVariableBlock.js
@@ -11,7 +11,8 @@ import type {Value} from '../interpreter/Value.js';
 import {
 	isLegalConstant, 
 	getNameAsConstant, 
-	isBuiltInVariable
+	isBuiltInVariable,
+	isDefaultVariableName,
 } from '../userInteraction/defaultVariableNames.js';
 
 import {
@@ -101,6 +102,19 @@ class GetVariableBlock extends CasusBlock {
 
 	getReturnType(): DataType {
 		return this.dataType;
+	}
+
+	getExistingVariableNames(dataType: DataType): Array<string> {
+		if (this.dataType !== dataType) {
+			return [];
+		}
+		const builtInVariable = isBuiltInVariable(this.variableName, this.dataType);
+		const legalConstant = isLegalConstant(this.variableName, this.dataType);
+		const isDefault = isDefaultVariableName(this.variableName);
+		if (builtInVariable || legalConstant || isDefault) {
+			return [];
+		}
+		return [this.variableName];
 	}
 
 	tryToPlace(v: Vec, blockToPlace: CasusBlock, ctx: ?CanvasRenderingContext2D): ?CasusBlock {

--- a/src/casus/blocks/SetVariableBlock.js
+++ b/src/casus/blocks/SetVariableBlock.js
@@ -8,6 +8,10 @@ import Vec from './Vec.js';
 import generateCornerPerim from './generateCornerPerim.js';
 import InterpriterState from '../interpreter/InterpriterState.js'
 import {getInterpriterState} from '../interpreter/InterpriterState.js'
+import {
+	isBuiltInVariable,
+	isLegalConstant,
+} from '../userInteraction/defaultVariableNames.js';
 
 import {
 	SET_VARIABLE_SET_WIDTH, 
@@ -82,7 +86,17 @@ class SetVariableBlock extends CasusBlock {
 	}
 
 	drawSelf(ctx: CanvasRenderingContext2D): void {
-		ctx.fillStyle = '#ff00cb';
+		const builtInVariable = isBuiltInVariable(this.variableName, this.paramType);
+		const legalConstant = isLegalConstant(this.variableName, this.paramType);
+		if (builtInVariable) {
+			ctx.fillStyle = '#3dc2dc';
+		}
+		else if (legalConstant) {
+			ctx.fillStyle = '#aaaaaa';
+		}
+		else {
+			ctx.fillStyle = '#ff00cb';
+		}
 
 		ctx.fillRect(this.boundingBox.x, this.boundingBox.y, this.boundingBox.w, this.boundingBox.h);
 

--- a/src/casus/blocks/SetVariableBlock.js
+++ b/src/casus/blocks/SetVariableBlock.js
@@ -11,6 +11,7 @@ import {getInterpriterState} from '../interpreter/InterpriterState.js'
 import {
 	isBuiltInVariable,
 	isLegalConstant,
+	isDefaultVariableName,
 } from '../userInteraction/defaultVariableNames.js';
 
 import {
@@ -125,6 +126,20 @@ class SetVariableBlock extends CasusBlock {
 
 	getReturnType(): DataType {
 		return 'VOID';
+	}
+
+	getExistingVariableNames(dataType: DataType): Array<string> {
+		if (this.paramType !== dataType) {
+			return [];
+		}
+		//if it is a constant or a built in variable, don't add it to the list
+		const builtInVariable = isBuiltInVariable(this.variableName, this.paramType);
+		const legalConstant = isLegalConstant(this.variableName, this.paramType);
+		const isDefault = isDefaultVariableName(this.variableName);
+		if (legalConstant || builtInVariable || isDefault) {
+			return [];
+		}
+		return [this.variableName];
 	}
 
 	tryToPlace(v: Vec, blockToPlace: CasusBlock, ctx: ?CanvasRenderingContext2D): ?CasusBlock {

--- a/src/casus/userInteraction/SelectVariablePopup.js
+++ b/src/casus/userInteraction/SelectVariablePopup.js
@@ -22,7 +22,8 @@ import './SelectVariablePopup.css';
 type Props = {|
 	variableBlockToRename: SetVariableBlock | GetVariableBlock | null,
 	onCancelClicked: () => void,
-	onVariableCreated: (string) => void
+	onVariableCreated: (variableName: string) => void,
+	getExistingVariableNames: (dataType: DataType) => Array<string>
 |};
 
 type State = {|
@@ -144,18 +145,25 @@ class SelectVariablePopup extends React.Component<Props, State> {
 
 	getPrepopulatedValues(): Array<string> {
 		const dataType=this.getExpectedDataType();
+		let prepopulatedValues=[];
 		switch(dataType) {
 			case 'INT':
-				return this.getPrepoulatedInts();
+				prepopulatedValues = this.getPrepoulatedInts();
+				break;
 			case 'DOUBLE':
-				return this.getPrepoulatedDoubles();
+				prepopulatedValues = this.getPrepoulatedDoubles();
+				break;
 			case 'BOOLEAN':
-				return this.getPrepopulatedBooleans();
+				prepopulatedValues = this.getPrepopulatedBooleans();
+				break;
 			case 'DOUBLE_LIST':
-				return this.getPrepopulatedDoubleLists();
+				prepopulatedValues = this.getPrepopulatedDoubleLists();
+				break;
 			default:
-				return [];
+				prepopulatedValues = [];
+				break;
 		}
+		return prepopulatedValues.concat(this.props.getExistingVariableNames(dataType));
 	}
 
 	getPrepoulatedInts(): Array<string> {

--- a/src/casus/userInteraction/defaultVariableNames.js
+++ b/src/casus/userInteraction/defaultVariableNames.js
@@ -5,6 +5,12 @@ import type {Value} from '../interpreter/Value.js';
 import IntValue from '../interpreter/IntValue.js';
 import BooleanValue from '../interpreter/BooleanValue.js';
 import DoubleValue from '../interpreter/DoubleValue.js';
+import {
+	builtInIntVariables, 
+	builtInBooleanVariables, 
+	builtInDoubleVariables, 
+	builtInDoubleListVariables
+} from './CasusSpecialVariables.js';
 
 const DEFAULT_INT_VARIABLE_NAME = '[Int variable]';
 const DEFAULT_DOUBLE_VARIABLE_NAME = '[Double variable]';
@@ -91,6 +97,24 @@ function getNameAsConstant(name: string, expectedType: DataType): ?Value {
 	return null;
 }
 
+function isBuiltInVariable(name: string, expectedType: DataType): boolean {
+	if (expectedType === 'BOOLEAN') {
+		return builtInBooleanVariables.includes(name);
+	}
+	else if (expectedType === 'INT') {
+		return builtInIntVariables.includes(name);
+	}
+	else if (expectedType === 'DOUBLE') {
+		return builtInDoubleVariables.includes(name);
+	}
+	else if (expectedType === 'DOUBLE_LIST') {
+		return builtInDoubleListVariables.includes(name);
+	}
+	else {
+		return false;
+	}
+}
+
 export {
 	DEFAULT_INT_VARIABLE_NAME,
 	DEFAULT_DOUBLE_VARIABLE_NAME,
@@ -111,4 +135,5 @@ export {
 	isLegalVariableName,
 	isLegalConstant,
 	getNameAsConstant,
+	isBuiltInVariable,
 };


### PR DESCRIPTION
**Description**
Constants are now a light-gray color. Built in variables are a sky-blue. User-created variables are the usual pink. Here is what things now look like:
![image](https://user-images.githubusercontent.com/18317476/78509224-a8bde280-775a-11ea-9eb7-fa7ef65e9955.png)

Also, the list of suggested variables now includes all variables you have used before. Here is an example of what that looks like:
![image](https://user-images.githubusercontent.com/18317476/78509238-c1c69380-775a-11ea-907b-fc009b88756a.png)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/78509248-e3277f80-775a-11ea-90fb-7c38d64d4e30.png)

**Resolves These Issues**
Resolves #372 
**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.