### PR TITLE
Made Casus stop executing after 50,000 statements per frame

### DIFF
--- a/src/casus/blocks/AndBlock.js
+++ b/src/casus/blocks/AndBlock.js
@@ -11,12 +11,12 @@ class AndBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyBoolean(this.lChild.evaluate());
+		const lRes=verifyBoolean(this.lChild.runEvaluate());
 		if (!lRes.val) {
 			return lRes;
 		}
 
-		const rRes=verifyBoolean(this.rChild.evaluate());
+		const rRes=verifyBoolean(this.rChild.runEvaluate());
 		return rRes;
 	}
 

--- a/src/casus/blocks/CasusBlock.js
+++ b/src/casus/blocks/CasusBlock.js
@@ -122,6 +122,7 @@ class CasusBlock {
 			interpriterState.incrementStatementsMade();
 			return this.evaluate();
 		}
+	}
 
 	getExistingVariableNames(dataType: DataType): Array<string> {
 		const allVariables=[];

--- a/src/casus/blocks/CasusBlock.js
+++ b/src/casus/blocks/CasusBlock.js
@@ -115,7 +115,7 @@ class CasusBlock {
 
 	runEvaluate(): ?Value {
 		const interpriterState = getInterpriterState();	
-		if (interpriterState.madeTooManyStatements()) {
+		if (interpriterState.madeTooManyStatements() && this.getReturnType() === 'VOID') {
 			return defaultValueFor(this.getReturnType());
 		}
 		else {

--- a/src/casus/blocks/CasusBlock.js
+++ b/src/casus/blocks/CasusBlock.js
@@ -3,6 +3,9 @@
 import BoundingBox from './BoundingBox.js';
 import Vec from './Vec.js';
 import {HIGHLIGHT_STROKE_WIDTH, BOARDER_STROKE_WIDTH} from './generateCornerPerim.js';
+import InterpriterState from '../interpreter/InterpriterState.js';
+import {getInterpriterState} from '../interpreter/InterpriterState.js';
+import {defaultValueFor} from '../interpreter/Value.js';
 
 import type {DataType} from './DataType.js';
 import type {Value} from '../interpreter/Value.js';
@@ -108,6 +111,17 @@ class CasusBlock {
 			}
 		}
 		return this.boundingBox.contains(v) ? this : null;
+	}
+
+	runEvaluate(): ?Value {
+		const interpriterState = getInterpriterState();	
+		if (interpriterState.madeTooManyStatements()) {
+			return defaultValueFor(this.getReturnType());
+		}
+		else {
+			interpriterState.incrementStatementsMade();
+			return this.evaluate();
+		}
 	}
 
 	//returns true if we were able to place it in some container, false otherwise

--- a/src/casus/blocks/ContainerBlock.js
+++ b/src/casus/blocks/ContainerBlock.js
@@ -150,7 +150,7 @@ class ContainerBlock extends CasusBlock {
 	
 	evaluate(): null {
 		for (const child: CasusBlock of this.children) {
-			child.evaluate();
+			child.runEvaluate();
 		}
 		return null;
 	}

--- a/src/casus/blocks/DoubleAbsBlock.js
+++ b/src/casus/blocks/DoubleAbsBlock.js
@@ -11,7 +11,7 @@ class DoubleAbsBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const childRes=verifyDouble(this.rChild.evaluate());
+		const childRes=verifyDouble(this.rChild.runEvaluate());
 		return childRes.abs();
 	}
 

--- a/src/casus/blocks/DoubleAddBlock.js
+++ b/src/casus/blocks/DoubleAddBlock.js
@@ -11,8 +11,8 @@ class DoubleAddBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.add(rRes);
 	}
 

--- a/src/casus/blocks/DoubleDivideBlock.js
+++ b/src/casus/blocks/DoubleDivideBlock.js
@@ -11,8 +11,8 @@ class DoubleDivideBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.div(rRes);
 	}
 

--- a/src/casus/blocks/DoubleEqualsBlock.js
+++ b/src/casus/blocks/DoubleEqualsBlock.js
@@ -11,8 +11,8 @@ class DoubleEqualsBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.equals(rRes));
 	}
 

--- a/src/casus/blocks/DoubleGreaterThanBlock.js
+++ b/src/casus/blocks/DoubleGreaterThanBlock.js
@@ -11,8 +11,8 @@ class DoubleGreaterThanBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.greaterThan(rRes));
 	}
 

--- a/src/casus/blocks/DoubleGreaterThanOrEqualBlock.js
+++ b/src/casus/blocks/DoubleGreaterThanOrEqualBlock.js
@@ -11,8 +11,8 @@ class DoubleGreaterThanOrEqualBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.equals(rRes) || lRes.greaterThan(rRes));
 	}
 

--- a/src/casus/blocks/DoubleLessThanBlock.js
+++ b/src/casus/blocks/DoubleLessThanBlock.js
@@ -11,8 +11,8 @@ class DoubleLessThanBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.lessThan(rRes));
 	}
 

--- a/src/casus/blocks/DoubleLessThanOrEqualBlock.js
+++ b/src/casus/blocks/DoubleLessThanOrEqualBlock.js
@@ -11,8 +11,8 @@ class DoubleLessThanOrEqualBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.equals(rRes) || lRes.lessThan(rRes));
 	}
 

--- a/src/casus/blocks/DoubleMaxBlock.js
+++ b/src/casus/blocks/DoubleMaxBlock.js
@@ -11,8 +11,8 @@ class DoubleMaxBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.maxWith(rRes);
 	}
 

--- a/src/casus/blocks/DoubleMinBlock.js
+++ b/src/casus/blocks/DoubleMinBlock.js
@@ -11,8 +11,8 @@ class DoubleMinBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.minWith(rRes);
 	}
 

--- a/src/casus/blocks/DoubleMultiplyBlock.js
+++ b/src/casus/blocks/DoubleMultiplyBlock.js
@@ -11,8 +11,8 @@ class DoubleMultiplyBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.mul(rRes);
 	}
 

--- a/src/casus/blocks/DoubleRoundBlock.js
+++ b/src/casus/blocks/DoubleRoundBlock.js
@@ -11,7 +11,7 @@ class DoubleRoundBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return rRes.round();
 	}
 

--- a/src/casus/blocks/DoubleSubtractBlock.js
+++ b/src/casus/blocks/DoubleSubtractBlock.js
@@ -11,8 +11,8 @@ class DoubleSubtractBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.sub(rRes);
 	}
 

--- a/src/casus/blocks/DoubleTruncateBlock.js
+++ b/src/casus/blocks/DoubleTruncateBlock.js
@@ -11,7 +11,7 @@ class DoubleTruncateBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return rRes.truncate();
 	}
 

--- a/src/casus/blocks/ForBlock.js
+++ b/src/casus/blocks/ForBlock.js
@@ -6,6 +6,8 @@ import EmptyBlock from './EmptyBlock.js';
 import ContainerBlock from './ContainerBlock.js';
 import Vec from './Vec.js';
 import {verifyBoolean} from '../interpreter/Value.js';
+import InterpriterState from '../interpreter/InterpriterState.js';
+import {getInterpriterState} from '../interpreter/InterpriterState.js';
 
 import type {DataType} from './DataType.js';
 
@@ -199,6 +201,9 @@ class ForBlock extends CasusBlock {
 	evaluate(): null {
 		this.initializationBlock.runEvaluate();
 		while (verifyBoolean(this.expressionBlock.runEvaluate()).val) {
+			if (getInterpriterState().madeTooManyStatements()) {
+				break;
+			}
 			this.contents.runEvaluate();
 			this.incrementBlock.runEvaluate();
 		}

--- a/src/casus/blocks/ForBlock.js
+++ b/src/casus/blocks/ForBlock.js
@@ -197,10 +197,10 @@ class ForBlock extends CasusBlock {
 	}
 
 	evaluate(): null {
-		this.initializationBlock.evaluate();
-		while (verifyBoolean(this.expressionBlock.evaluate()).val) {
-			this.contents.evaluate();
-			this.incrementBlock.evaluate();
+		this.initializationBlock.runEvaluate();
+		while (verifyBoolean(this.expressionBlock.runEvaluate()).val) {
+			this.contents.runEvaluate();
+			this.incrementBlock.runEvaluate();
 		}
 		return null;
 	}

--- a/src/casus/blocks/GetListAtBlock.js
+++ b/src/casus/blocks/GetListAtBlock.js
@@ -142,7 +142,7 @@ class GetListAtBlock extends CasusBlock {
 	}
 
 	evaluate(): ?Value {
-		const index = verifyInt(this.indexBlock.evaluate());
+		const index = verifyInt(this.indexBlock.runEvaluate());
 		const interpreter: InterpriterState = getInterpriterState();
 		const expectedListType = listVersionOf(this.paramType);
 		if (!(this.list instanceof GetVariableBlock)) {

--- a/src/casus/blocks/IfBlock.js
+++ b/src/casus/blocks/IfBlock.js
@@ -14,9 +14,9 @@ class IfBlock extends SingleConditionHeader {
 	}
 
 	evaluate(): null {
-		const condition=verifyBoolean(this.conditionBlock.evaluate());
+		const condition=verifyBoolean(this.conditionBlock.runEvaluate());
 		if (condition.val) {
-			this.contents.evaluate();
+			this.contents.runEvaluate();
 		}
 		return null;
 	}

--- a/src/casus/blocks/IfElseBlock.js
+++ b/src/casus/blocks/IfElseBlock.js
@@ -178,12 +178,12 @@ class IfElseBlock extends CasusBlock {
 	}
 
 	evaluate(): null {
-		const condition=verifyBoolean(this.conditionBlock.evaluate());
+		const condition=verifyBoolean(this.conditionBlock.runEvaluate());
 		if (condition.val) {
-			return this.ifContents.evaluate();
+			return this.ifContents.runEvaluate();
 		}
 		else {
-			return this.elseContents.evaluate();
+			return this.elseContents.runEvaluate();
 		}
 	}
 

--- a/src/casus/blocks/IfElseBlock.js
+++ b/src/casus/blocks/IfElseBlock.js
@@ -8,6 +8,7 @@ import Vec from './Vec.js';
 import {verifyBoolean} from '../interpreter/Value.js';
 
 import type {DataType} from './DataType.js';
+import type {Value} from '../interpreter/Value.js';
 
 import {
 	IF_BLOCK_IF_WIDTH,
@@ -177,7 +178,7 @@ class IfElseBlock extends CasusBlock {
 		return null;
 	}
 
-	evaluate(): null {
+	evaluate(): ?Value {
 		const condition=verifyBoolean(this.conditionBlock.runEvaluate());
 		if (condition.val) {
 			return this.ifContents.runEvaluate();

--- a/src/casus/blocks/IntAbsBlock.js
+++ b/src/casus/blocks/IntAbsBlock.js
@@ -11,7 +11,7 @@ class IntAbsBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const childRes=verifyInt(this.rChild.evaluate());
+		const childRes=verifyInt(this.rChild.runEvaluate());
 		return childRes.abs();
 	}
 

--- a/src/casus/blocks/IntAddBlock.js
+++ b/src/casus/blocks/IntAddBlock.js
@@ -11,8 +11,8 @@ class IntAddBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.add(rRes);
 	}
 

--- a/src/casus/blocks/IntDivideBlock.js
+++ b/src/casus/blocks/IntDivideBlock.js
@@ -11,8 +11,8 @@ class IntDivideBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.div(rRes);
 	}
 

--- a/src/casus/blocks/IntEqualsBlock.js
+++ b/src/casus/blocks/IntEqualsBlock.js
@@ -11,8 +11,8 @@ class IntEqualsBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.equals(rRes));
 	}
 

--- a/src/casus/blocks/IntGreaterThanBlock.js
+++ b/src/casus/blocks/IntGreaterThanBlock.js
@@ -11,8 +11,8 @@ class IntGreaterThanBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.greaterThan(rRes));
 	}
 

--- a/src/casus/blocks/IntGreaterThanOrEqualBlock.js
+++ b/src/casus/blocks/IntGreaterThanOrEqualBlock.js
@@ -11,8 +11,8 @@ class IntGreaterThanOrEqualBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.equals(rRes) || lRes.greaterThan(rRes));
 	}
 

--- a/src/casus/blocks/IntLessThanBlock.js
+++ b/src/casus/blocks/IntLessThanBlock.js
@@ -11,8 +11,8 @@ class IntLessThanBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.lessThan(rRes));
 	}
 

--- a/src/casus/blocks/IntLessThanOrEqualBlock.js
+++ b/src/casus/blocks/IntLessThanOrEqualBlock.js
@@ -11,8 +11,8 @@ class IntLessThanOrEqualBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return new BooleanValue(lRes.equals(rRes) || lRes.lessThan(rRes));
 	}
 

--- a/src/casus/blocks/IntMaxBlock.js
+++ b/src/casus/blocks/IntMaxBlock.js
@@ -11,8 +11,8 @@ class IntMaxBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.maxWith(rRes);
 	}
 

--- a/src/casus/blocks/IntMinBlock.js
+++ b/src/casus/blocks/IntMinBlock.js
@@ -11,8 +11,8 @@ class IntMinBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.minWith(rRes);
 	}
 

--- a/src/casus/blocks/IntModuloBlock.js
+++ b/src/casus/blocks/IntModuloBlock.js
@@ -11,8 +11,8 @@ class IntModuloBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.mod(rRes);
 	}
 

--- a/src/casus/blocks/IntMultiplyBlock.js
+++ b/src/casus/blocks/IntMultiplyBlock.js
@@ -11,8 +11,8 @@ class IntMultiplyBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.mul(rRes);
 	}
 

--- a/src/casus/blocks/IntSubtractBlock.js
+++ b/src/casus/blocks/IntSubtractBlock.js
@@ -11,8 +11,8 @@ class IntSubtractBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): IntValue {
-		const lRes=verifyInt(this.lChild.evaluate());
-		const rRes=verifyInt(this.rChild.evaluate());
+		const lRes=verifyInt(this.lChild.runEvaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return lRes.sub(rRes);
 	}
 

--- a/src/casus/blocks/IntToDoubleBlock.js
+++ b/src/casus/blocks/IntToDoubleBlock.js
@@ -11,7 +11,7 @@ class IntToDoubleBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const rRes=verifyInt(this.rChild.evaluate());
+		const rRes=verifyInt(this.rChild.runEvaluate());
 		return rRes.toDoubleValue();
 	}
 

--- a/src/casus/blocks/ListAppendBlock.js
+++ b/src/casus/blocks/ListAppendBlock.js
@@ -20,8 +20,8 @@ class ListAppendBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): null {
-		const toAppend = this.lChild.evaluate();
-		const list = this.rChild.evaluate();
+		const toAppend = this.lChild.runEvaluate();
+		const list = this.rChild.runEvaluate();
 		switch(this.paramType) {
 			case 'INT':
 				verifyIntList(list).append(verifyInt(toAppend));

--- a/src/casus/blocks/ListSizeBlock.js
+++ b/src/casus/blocks/ListSizeBlock.js
@@ -117,7 +117,7 @@ class ListSizeBlock extends CasusBlock {
 	}
 
 	evaluate(): IntValue {
-		const list=this.list.evaluate();
+		const list=this.list.runEvaluate();
 		switch (this.paramType) {
 			case 'INT':
 				return verifyIntList(list).sizeOf();

--- a/src/casus/blocks/MathAcosBlock.js
+++ b/src/casus/blocks/MathAcosBlock.js
@@ -11,7 +11,7 @@ class MathAcosBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const res=verifyDouble(this.rChild.evaluate());
+		const res=verifyDouble(this.rChild.runEvaluate());
 		return res.arccos();
 	}
 

--- a/src/casus/blocks/MathAsinBlock.js
+++ b/src/casus/blocks/MathAsinBlock.js
@@ -11,7 +11,7 @@ class MathAsinBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const res=verifyDouble(this.rChild.evaluate());
+		const res=verifyDouble(this.rChild.runEvaluate());
 		return res.arcsin();
 	}
 

--- a/src/casus/blocks/MathAtanBlock.js
+++ b/src/casus/blocks/MathAtanBlock.js
@@ -11,7 +11,7 @@ class MathAtanBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const res=verifyDouble(this.rChild.evaluate());
+		const res=verifyDouble(this.rChild.runEvaluate());
 		return res.arctan();
 	}
 

--- a/src/casus/blocks/MathCosBlock.js
+++ b/src/casus/blocks/MathCosBlock.js
@@ -11,7 +11,7 @@ class MathCosBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const res=verifyDouble(this.rChild.evaluate());
+		const res=verifyDouble(this.rChild.runEvaluate());
 		return res.cos();
 	}
 

--- a/src/casus/blocks/MathPowBlock.js
+++ b/src/casus/blocks/MathPowBlock.js
@@ -11,8 +11,8 @@ class MathPowBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const lRes=verifyDouble(this.lChild.evaluate());
-		const rRes=verifyDouble(this.rChild.evaluate());
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
 		return lRes.pow(rRes);
 	}
 

--- a/src/casus/blocks/MathSqrtBlock.js
+++ b/src/casus/blocks/MathSqrtBlock.js
@@ -11,7 +11,7 @@ class MathSqrtBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const res=verifyDouble(this.rChild.evaluate());
+		const res=verifyDouble(this.rChild.runEvaluate());
 		return res.sqrt();
 	}
 

--- a/src/casus/blocks/MathTanBlock.js
+++ b/src/casus/blocks/MathTanBlock.js
@@ -11,7 +11,7 @@ class MathTanBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): DoubleValue {
-		const res=verifyDouble(this.rChild.evaluate());
+		const res=verifyDouble(this.rChild.runEvaluate());
 		return res.tan();
 	}
 

--- a/src/casus/blocks/NotBlock.js
+++ b/src/casus/blocks/NotBlock.js
@@ -11,7 +11,7 @@ class NotBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const res=verifyBoolean(this.rChild.evaluate());
+		const res=verifyBoolean(this.rChild.runEvaluate());
 		return res.not();
 	}
 

--- a/src/casus/blocks/OrBlock.js
+++ b/src/casus/blocks/OrBlock.js
@@ -11,12 +11,12 @@ class OrBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyBoolean(this.lChild.evaluate());
+		const lRes=verifyBoolean(this.lChild.runEvaluate());
 		if (lRes.val) {
 			return lRes;
 		}
 
-		const rRes=verifyBoolean(this.rChild.evaluate());
+		const rRes=verifyBoolean(this.rChild.runEvaluate());
 		return rRes;
 	}
 

--- a/src/casus/blocks/PrintBlock.js
+++ b/src/casus/blocks/PrintBlock.js
@@ -10,7 +10,7 @@ class PrintBlock extends UnaryOperationBlock {
 	}
 
 	evaluate(): null {
-		const res=this.rChild.evaluate();
+		const res=this.rChild.runEvaluate();
 		console.log(res);
 		return null;
 	}

--- a/src/casus/blocks/SetListAtBlock.js
+++ b/src/casus/blocks/SetListAtBlock.js
@@ -171,9 +171,9 @@ class SetListAtBlock extends CasusBlock {
 	}
 
 	evaluate(): null {
-		const list = this.list.evaluate();
-		const index = verifyInt(this.indexBlock.evaluate());
-		const value = this.expressionBlock.evaluate();
+		const list = this.list.runEvaluate();
+		const index = verifyInt(this.indexBlock.runEvaluate());
+		const value = this.expressionBlock.runEvaluate();
 		switch (this.paramType) {
 			case 'INT':
 				verifyIntList(list).setAt(index, verifyInt(value));

--- a/src/casus/blocks/SetVariableBlock.js
+++ b/src/casus/blocks/SetVariableBlock.js
@@ -123,7 +123,7 @@ class SetVariableBlock extends CasusBlock {
 
 	evaluate(): null {
 		const interpreter : InterpriterState = getInterpriterState();
-		const setTo = this.expressionBlock.evaluate();
+		const setTo = this.expressionBlock.runEvaluate();
 		if (setTo == null) {
 			throw new Error('Didnt expect expression block to return null!');
 		}

--- a/src/casus/blocks/WhileBlock.js
+++ b/src/casus/blocks/WhileBlock.js
@@ -12,8 +12,8 @@ class WhileBlock extends SingleConditionHeader {
 	}
 	
 	evaluate(): null {
-		while (verifyBoolean(this.conditionBlock.evaluate()).val) {
-			this.contents.evaluate();
+		while (verifyBoolean(this.conditionBlock.runEvaluate()).val) {
+			this.contents.runEvaluate();
 		}
 		return null;
 	}

--- a/src/casus/blocks/WhileBlock.js
+++ b/src/casus/blocks/WhileBlock.js
@@ -5,6 +5,8 @@ import {verifyBoolean} from '../interpreter/Value.js';
 import {
 	WHILE_BLOCK_WHILE_WIDTH
 } from './generateCornerPerim.js';
+import InterpriterState from '../interpreter/InterpriterState.js';
+import {getInterpriterState} from '../interpreter/InterpriterState.js';
 
 class WhileBlock extends SingleConditionHeader {
 	constructor() {
@@ -13,6 +15,9 @@ class WhileBlock extends SingleConditionHeader {
 	
 	evaluate(): null {
 		while (verifyBoolean(this.conditionBlock.runEvaluate()).val) {
+			if (getInterpriterState().madeTooManyStatements()) {
+				break;
+			}
 			this.contents.runEvaluate();
 		}
 		return null;

--- a/src/casus/blocks/XorBlock.js
+++ b/src/casus/blocks/XorBlock.js
@@ -11,8 +11,8 @@ class XorBlock extends BinaryOperationBlock {
 	}
 
 	evaluate(): BooleanValue {
-		const lRes=verifyBoolean(this.lChild.evaluate());
-		const rRes=verifyBoolean(this.rChild.evaluate());
+		const lRes=verifyBoolean(this.lChild.runEvaluate());
+		const rRes=verifyBoolean(this.rChild.runEvaluate());
 		return lRes.xor(rRes);
 	}
 }

--- a/src/casus/interpreter/InterpriterState.js
+++ b/src/casus/interpreter/InterpriterState.js
@@ -22,6 +22,8 @@ import {
 import type {Value} from './Value.js';
 import type {DataType} from '../blocks/DataType.js';
 
+const MAX_STATEMENTS=5e4;
+
 class InterpriterState {
 	intVariables: Map<string, IntValue>;
 	booleanVariables: Map<string, BooleanValue>;
@@ -29,6 +31,7 @@ class InterpriterState {
 	intListVariables: Map<string, IntListValue>;
 	booleanListVariables: Map<string, BooleanListValue>;
 	doubleListVariables: Map<string, DoubleListValue>;
+	statementsMade: number;
 	
 	constructor() {
 		this.intVariables = new Map<string, IntValue>();
@@ -97,6 +100,18 @@ class InterpriterState {
 			default:
 				console.log('Unexpected variable type '+type+' in InterpreterState.setVariable!');
 		}
+	}
+
+	incrementStatementsMade(): void {
+		this.statementsMade++;
+	}
+
+	madeTooManyStatements(): boolean {
+		return this.statementsMade > MAX_STATEMENTS;
+	}
+
+	resetStatementsMade(): void {
+		this.statementsMade = 0;
 	}
 }
 

--- a/src/tanks/Tank.js
+++ b/src/tanks/Tank.js
@@ -174,7 +174,7 @@ class Tank extends GameObject {
 	executeCasusFrame(): void {
 		this.interpriterState.resetStatementsMade();
 		setInterpriterState(this.interpriterState);	
-		this.casusCode.evaluate();
+		this.casusCode.runEvaluate();
 		this.interpriterState = getInterpriterState();
 	}
 	

--- a/src/tanks/Tank.js
+++ b/src/tanks/Tank.js
@@ -172,6 +172,7 @@ class Tank extends GameObject {
 	}
 
 	executeCasusFrame(): void {
+		this.interpriterState.resetStatementsMade();
 		setInterpriterState(this.interpriterState);	
 		this.casusCode.evaluate();
 		this.interpriterState = getInterpriterState();


### PR DESCRIPTION
**Description**
Made Casus code no longer crash the browser if it has an infinite loop. Here is a gif of a tank (bottom left) running with an infinite loop:
![InfiniteLoop2](https://user-images.githubusercontent.com/18317476/78510586-4669df80-7764-11ea-94bb-3cd8d5a1a5d1.gif)


Passes flow:
![image](https://user-images.githubusercontent.com/18317476/78510551-e8d59300-7763-11ea-84c7-b7e71cd70552.png)

**Resolves These Issues**
Resolves #184 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
Create a tank with an infinite (or insanely long) loop. When you battle with it, it shouldn't crash the browser.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)