### PR TITLE
Made armory show the name of the tank being edited by Casus in the navbar

### DIFF
--- a/src/casus/CasusContainer.js
+++ b/src/casus/CasusContainer.js
@@ -6,11 +6,14 @@ import CasusEditor from './CasusEditor.js';
 import CasusBlock from './blocks/CasusBlock.js';
 import Navbar from '../globalComponents/Navbar.js';
 import { verifyLogin } from '../globalComponents/apiCalls/verifyLogin.js';
+import getTankForCasus from '../globalComponents/getTankForCasus.js';
+import {getAllUsersTanks} from '../globalComponents/apiCalls/tankAPIIntegration.js';
 
 type Props = {||};
 
 type State = {
-	draggedBlocks: ?Array<CasusBlock>
+	draggedBlocks: ?Array<CasusBlock>,
+	tankName: string,
 };
 
 class CasusContainer extends React.Component<Props, State> {
@@ -19,8 +22,15 @@ class CasusContainer extends React.Component<Props, State> {
 		super(props);
 		verifyLogin();
 		this.state = {
-			draggedBlocks: null
+			draggedBlocks: null,
+			tankName: 'loading tank...'
 		};
+
+		const tankId=getTankForCasus();
+		getAllUsersTanks((successful, allTanks) => {
+			const tankEditing = allTanks.find(t => t._id === tankId);
+			this.setState({tankName: tankEditing?.tankName ?? ''});
+		});
 	}
 
 	render(): React.Node {
@@ -29,7 +39,7 @@ class CasusContainer extends React.Component<Props, State> {
 				<Navbar
 					linkName='/Armory'
 					returnName='Back to Armory'
-					pageName='Casus'
+					pageName={'Casus for '+this.state.tankName}
 				/>
 				<BlockBank 
 					draggedBlocks={this.state.draggedBlocks}

--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -24,7 +24,7 @@ type State = {|
 	mouseX: number,
 	mouseY: number,
 	mouseOnScreen: boolean,
-	variableBlockToRename: GetVariableBlock | SetVariableBlock | null
+	variableBlockToRename: GetVariableBlock | SetVariableBlock | null,
 |};
 
 type MouseEvent = {
@@ -41,7 +41,6 @@ const RIGHT_BUTTON_CODE=2;
 
 class CasusEditor extends React.Component<Props, State> {
 	
-
 	constructor(props: Props) {
 		super(props);
 
@@ -50,7 +49,7 @@ class CasusEditor extends React.Component<Props, State> {
 		loadCasus(
 			casusBlock => {
 				this.setState({
-					containerBlock: casusBlock
+					containerBlock: casusBlock,
 				});
 				this._rerender();
 			}
@@ -61,7 +60,7 @@ class CasusEditor extends React.Component<Props, State> {
 			mouseX: 0,
 			mouseY: 0,
 			mouseOnScreen: false,
-			variableBlockToRename: null
+			variableBlockToRename: null,
 		}
 	}
 

--- a/src/casus/loadCasus.js
+++ b/src/casus/loadCasus.js
@@ -5,7 +5,10 @@ import getTankForCasus from '../globalComponents/getTankForCasus.js';
 import ContainerBlock from './blocks/ContainerBlock.js';
 import reviveCasusBlock from './reviveCasusBlock.js';
 
-function loadCasus(onBlocksLoaded: (casusBlock: ContainerBlock) => void, tankId: ?string = null): void {
+function loadCasus(
+	onBlocksLoaded: (casusBlock: ContainerBlock) => void, 
+	tankId: ?string = null
+): void {
 	const targetTankId = tankId ?? getTankForCasus();
 	if (targetTankId == null) {
 		throw new Error('No target tankId has been set!');


### PR DESCRIPTION
**Description**
You can now see which tank you are editing in casus in the navbar. Here's what it looks like:
![image](https://user-images.githubusercontent.com/18317476/78511875-1d4e4c80-776e-11ea-9f14-37707a37cca3.png)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/78511900-55ee2600-776e-11ea-8137-69d205f0327f.png)

**Resolves These Issues**
Resolves #374 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
Go edit a tank's code and see its name in the navbar on casus

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)