### PR TITLE
Added rightclick copying for Casus

### DIFF
--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -12,6 +12,7 @@ import {isDefaultVariableName} from './userInteraction/defaultVariableNames.js';
 import './CasusEditor.css';
 import saveCasus from './saveCasus.js';
 import loadCasus from './loadCasus.js';
+import casusBlockDeepClone from './casusBlockDeepClone.js';
 
 type Props = {|
 	draggedBlocks: ?Array<CasusBlock>,
@@ -41,10 +42,8 @@ const RIGHT_BUTTON_CODE=2;
 
 class CasusEditor extends React.Component<Props, State> {
 	
-
 	constructor(props: Props) {
 		super(props);
-
 		const containerBlock: ContainerBlock = new ContainerBlock([]);
 
 		loadCasus(
@@ -140,10 +139,13 @@ class CasusEditor extends React.Component<Props, State> {
 		
 		let toSelect: Array<CasusBlock> = [];
 		if (rightButton) {
-			toSelect = this.state.containerBlock.removeBlockAt(eventPos, true);
+			const wouldHaveRemoved = this.state.containerBlock.removeBlockAt(eventPos, false, true);
+			for (const block of wouldHaveRemoved) {
+				toSelect.push(casusBlockDeepClone(block));
+			}
 		}
 		else {
-			toSelect = this.state.containerBlock.removeBlockAt(eventPos, false);
+			toSelect = this.state.containerBlock.removeBlockAt(eventPos, true, false);
 		}
 		if (toSelect.length > 0) {
 			this.props.onBlocksDragged(toSelect);
@@ -172,7 +174,8 @@ class CasusEditor extends React.Component<Props, State> {
 		const block=this.state.variableBlockToRename;
 		if (block!=null) {
 			const toRemovePos=new Vec(block.boundingBox.x+1, block.boundingBox.y+1);
-			this.state.containerBlock.removeBlockAt(toRemovePos, false);
+			//TODO: only remove the block if it was successfully placed!
+			this.state.containerBlock.removeBlockAt(toRemovePos, false, false);
 		}
 
 		this.setState({variableBlockToRename: null});

--- a/src/casus/blocks/BinaryOperationBlock.js
+++ b/src/casus/blocks/BinaryOperationBlock.js
@@ -87,27 +87,31 @@ class BinaryOperationBlock extends CasusBlock {
 		return [this.lChild, this.rChild];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
 		if (!this.boundingBox.contains(v)) {
 			return [];
 		}
-		const lChildRes = this.lChild.removeBlockAt(v, removeAfter);
+		const lChildRes = this.lChild.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (lChildRes.length > 0) {
 			return lChildRes;
 		}
 		if (this.lChild.boundingBox.contains(v) && this.lChild.draggable()) {
 			const toReturn=[this.lChild];
-			this.lChild=new EmptyBlock(this.paramType);
+			if (!justReturnCopy) {
+				this.lChild=new EmptyBlock(this.paramType);
+			}
 			return toReturn;
 		}
 
-		const rChildRes = this.rChild.removeBlockAt(v, removeAfter);
+		const rChildRes = this.rChild.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (rChildRes.length > 0) {
 			return rChildRes;
 		}
 		if (this.rChild.boundingBox.contains(v) && this.rChild.draggable()) {
 			const toReturn=[this.rChild];
-			this.rChild=new EmptyBlock(this.rightParamType);
+			if (!justReturnCopy) {
+				this.rChild=new EmptyBlock(this.rightParamType);
+			}
 			return toReturn;
 		}
 

--- a/src/casus/blocks/CasusBlock.js
+++ b/src/casus/blocks/CasusBlock.js
@@ -145,7 +145,7 @@ class CasusBlock {
 		return [];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
 		return [];
 	}
 

--- a/src/casus/blocks/ContainerBlock.js
+++ b/src/casus/blocks/ContainerBlock.js
@@ -44,19 +44,25 @@ class ContainerBlock extends CasusBlock {
 		return this.children;
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
 		for (let i=0; i<this.children.length; i++) {
 			const child: CasusBlock = this.children[i];
-			const childRes = child.removeBlockAt(v, removeAfter);
+			const childRes = child.removeBlockAt(v, removeAfter, justReturnCopy);
 			if (childRes.length > 0) {
 				return childRes;
 			}
 			if (child.boundingBox.contains(v) && child.draggable()) {
-				const toReturn=removeAfter? this.children.splice(i) : this.children.splice(i, 1);
-				if (this.children.length === 0) {
-					this.children.push(new EmptyBlock('VOID'));
+				if (justReturnCopy) {
+					const toReturn = removeAfter ? this.children.slice(i) : this.children.slice(i, i+1);
+					return toReturn;
 				}
-				return toReturn;
+				else {
+					const toReturn = removeAfter ? this.children.splice(i) : this.children.splice(i, 1);
+					if (this.children.length === 0) {
+						this.children.push(new EmptyBlock('VOID'));
+					}
+					return toReturn;
+				}
 			}
 		}
 

--- a/src/casus/blocks/ForBlock.js
+++ b/src/casus/blocks/ForBlock.js
@@ -107,36 +107,42 @@ class ForBlock extends CasusBlock {
 		return [this.initializationBlock, this.expressionBlock, this.incrementBlock, this.contents];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const initializationRes = this.initializationBlock.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const initializationRes = this.initializationBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (initializationRes.length > 0) {
 			return initializationRes;
 		}
 		if (this.initializationBlock.boundingBox.contains(v) && this.initializationBlock.draggable()) {
 			const toReturn = [this.initializationBlock];
-			this.initializationBlock = new EmptyBlock('VOID');
+			if (!justReturnCopy) {
+				this.initializationBlock = new EmptyBlock('VOID');
+			}
 			return toReturn;
 		}
-		const expressionRes=this.expressionBlock.removeBlockAt(v, removeAfter);
+		const expressionRes=this.expressionBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (expressionRes.length > 0) {
 			return expressionRes;
 		}
 		if (this.expressionBlock.boundingBox.contains(v) && this.expressionBlock.draggable()) {
 			const toReturn = [this.expressionBlock];
-			this.expressionBlock = new EmptyBlock('BOOLEAN');
+			if (!justReturnCopy) {
+				this.expressionBlock = new EmptyBlock('BOOLEAN');
+			}
 			return toReturn;
 		}
-		const incrementRes = this.incrementBlock.removeBlockAt(v, removeAfter);
+		const incrementRes = this.incrementBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (incrementRes.length > 0) {
 			return incrementRes;
 		}
 		if (this.incrementBlock.boundingBox.contains(v) && this.incrementBlock.draggable()) {
 			const toReturn = [this.incrementBlock];
-			this.incrementBlock = new EmptyBlock('VOID');
+			if (!justReturnCopy) {
+				this.incrementBlock = new EmptyBlock('VOID');
+			}
 			return toReturn;
 		}
 
-		return this.contents.removeBlockAt(v, removeAfter);
+		return this.contents.removeBlockAt(v, removeAfter, justReturnCopy);
 	}
 
 	drawSelf(ctx: CanvasRenderingContext2D): void {

--- a/src/casus/blocks/GetListAtBlock.js
+++ b/src/casus/blocks/GetListAtBlock.js
@@ -75,24 +75,28 @@ class GetListAtBlock extends CasusBlock {
 		return [this.list, this.indexBlock];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const listRes=this.list.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const listRes=this.list.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (listRes.length > 0) {
 			return listRes;
 		}
 		if (this.list.boundingBox.contains(v) && this.list.draggable()) {
 			const toReturn=[this.list];
-			this.list = new EmptyBlock(listVersionOf(this.paramType));
+			if (!justReturnCopy) {
+				this.list = new EmptyBlock(listVersionOf(this.paramType));
+			}
 			return toReturn;
 		}
 
-		const indexRes=this.indexBlock.removeBlockAt(v, removeAfter);
+		const indexRes=this.indexBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (indexRes.length > 0) {
 			return indexRes;
 		}
 		if (this.indexBlock.boundingBox.contains(v) && this.indexBlock.draggable()) {
 			const toReturn=[this.indexBlock];
-			this.indexBlock=new EmptyBlock('INT');
+			if (!justReturnCopy) {
+				this.indexBlock=new EmptyBlock('INT');
+			}
 			return toReturn;
 		}
 

--- a/src/casus/blocks/GetVariableBlock.js
+++ b/src/casus/blocks/GetVariableBlock.js
@@ -54,7 +54,7 @@ class GetVariableBlock extends CasusBlock {
 		return [];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
 		return [];
 	}
 

--- a/src/casus/blocks/IfElseBlock.js
+++ b/src/casus/blocks/IfElseBlock.js
@@ -112,22 +112,24 @@ class IfElseBlock extends CasusBlock {
 		return [this.conditionBlock, this.ifContents, this.elseContents];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const conditionRes = this.conditionBlock.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const conditionRes = this.conditionBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (conditionRes.length > 0) {
 			return conditionRes;
 		}
 		if (this.conditionBlock.boundingBox.contains(v) && this.conditionBlock.draggable()) {
 			const toReturn = [this.conditionBlock];
-			this.conditionBlock = new EmptyBlock('BOOLEAN');
+			if (!justReturnCopy) {
+				this.conditionBlock = new EmptyBlock('BOOLEAN');
+			}
 			return toReturn;
 		}
 
-		const ifContentsRes = this.ifContents.removeBlockAt(v, removeAfter);
+		const ifContentsRes = this.ifContents.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (ifContentsRes.length > 0) {
 			return ifContentsRes;
 		}
-		return this.elseContents.removeBlockAt(v, removeAfter);
+		return this.elseContents.removeBlockAt(v, removeAfter, justReturnCopy);
 	}
 
 	drawSelf(ctx: CanvasRenderingContext2D): void {

--- a/src/casus/blocks/ListSizeBlock.js
+++ b/src/casus/blocks/ListSizeBlock.js
@@ -61,14 +61,16 @@ class ListSizeBlock extends CasusBlock {
 		return [this.list];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const listRes=this.list.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const listRes=this.list.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (listRes.length > 0) {
 			return listRes;
 		}
 		if (this.list.boundingBox.contains(v) && this.list.draggable()) {
 			const toReturn=[this.list];
-			this.list = new EmptyBlock(listVersionOf(this.paramType));
+			if (!justReturnCopy) {
+				this.list = new EmptyBlock(listVersionOf(this.paramType));
+			}
 			return toReturn;
 		}
 

--- a/src/casus/blocks/SetListAtBlock.js
+++ b/src/casus/blocks/SetListAtBlock.js
@@ -85,34 +85,40 @@ class SetListAtBlock extends CasusBlock {
 		return [this.list, this.indexBlock, this.expressionBlock];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const listRes=this.list.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const listRes=this.list.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (listRes.length > 0) {
 			return listRes;
 		}
 		if (this.list.boundingBox.contains(v) && this.list.draggable()) {
 			const toReturn=[this.list];
-			this.list = new EmptyBlock(listVersionOf(this.paramType));
+			if (!justReturnCopy) {
+				this.list = new EmptyBlock(listVersionOf(this.paramType));
+			}
 			return toReturn;
 		}
 
-		const indexRes=this.indexBlock.removeBlockAt(v, removeAfter);
+		const indexRes=this.indexBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (indexRes.length > 0) {
 			return indexRes;
 		}
 		if (this.indexBlock.boundingBox.contains(v) && this.indexBlock.draggable()) {
 			const toReturn=[this.indexBlock];
-			this.indexBlock=new EmptyBlock('INT');
+			if (!justReturnCopy) {
+				this.indexBlock=new EmptyBlock('INT');
+			}
 			return toReturn;
 		}
 
-		const expressionRes=this.expressionBlock.removeBlockAt(v, removeAfter);
+		const expressionRes=this.expressionBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (expressionRes.length > 0) {
 			return expressionRes;
 		}
 		if (this.expressionBlock.boundingBox.contains(v) && this.expressionBlock.draggable()) {
 			const toReturn=[this.expressionBlock];
-			this.expressionBlock=new EmptyBlock(this.paramType);
+			if (!justReturnCopy) {
+				this.expressionBlock=new EmptyBlock(this.paramType);
+			}
 			return toReturn;
 		}
 		return [];

--- a/src/casus/blocks/SetVariableBlock.js
+++ b/src/casus/blocks/SetVariableBlock.js
@@ -64,14 +64,16 @@ class SetVariableBlock extends CasusBlock {
 		return [this.expressionBlock];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const expressionRes=this.expressionBlock.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const expressionRes=this.expressionBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (expressionRes.length > 0) {
 			return expressionRes;
 		}
 		if (this.expressionBlock.boundingBox.contains(v) && this.expressionBlock.draggable()) {
 			const toReturn=[this.expressionBlock];
-			this.expressionBlock=new EmptyBlock(this.paramType);
+			if (!justReturnCopy) {
+				this.expressionBlock=new EmptyBlock(this.paramType);
+			}
 			return toReturn;
 		}
 		return [];

--- a/src/casus/blocks/SingleConditionHeader.js
+++ b/src/casus/blocks/SingleConditionHeader.js
@@ -87,18 +87,20 @@ class SingleConditionHeader extends CasusBlock {
 		return [this.conditionBlock, this.contents];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
-		const conditionRes = this.conditionBlock.removeBlockAt(v, removeAfter);
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
+		const conditionRes = this.conditionBlock.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (conditionRes.length > 0) {
 			return conditionRes;
 		}
 		if (this.conditionBlock.boundingBox.contains(v) && this.conditionBlock.draggable()) {
 			const toReturn = [this.conditionBlock];
-			this.conditionBlock = new EmptyBlock('BOOLEAN');
+			if (!justReturnCopy) {
+				this.conditionBlock = new EmptyBlock('BOOLEAN');
+			}
 			return toReturn;
 		}
 
-		return this.contents.removeBlockAt(v, removeAfter);
+		return this.contents.removeBlockAt(v, removeAfter, justReturnCopy);
 	}
 
 	drawSelf(ctx: CanvasRenderingContext2D): void {

--- a/src/casus/blocks/UnaryOperationBlock.js
+++ b/src/casus/blocks/UnaryOperationBlock.js
@@ -55,18 +55,20 @@ class UnaryOperationBlock extends CasusBlock {
 		return [this.rChild];
 	}
 
-	removeBlockAt(v: Vec, removeAfter: boolean): Array<CasusBlock> {
+	removeBlockAt(v: Vec, removeAfter: boolean, justReturnCopy: boolean): Array<CasusBlock> {
 		if (!this.boundingBox.contains(v)) {
 			return [];
 		}
 
-		const rChildRes = this.rChild.removeBlockAt(v, removeAfter);
+		const rChildRes = this.rChild.removeBlockAt(v, removeAfter, justReturnCopy);
 		if (rChildRes.length > 0) {
 			return rChildRes;
 		}
 		if (this.rChild.boundingBox.contains(v) && this.rChild.draggable()) {
 			const toReturn=[this.rChild];
-			this.rChild=new EmptyBlock(this.paramType);
+			if (!justReturnCopy) {
+				this.rChild=new EmptyBlock(this.paramType);
+			}
 			return toReturn;
 		}
 

--- a/src/casus/casusBlockDeepClone.js
+++ b/src/casus/casusBlockDeepClone.js
@@ -1,0 +1,15 @@
+//@flow strict
+
+import CasusBlock from './blocks/CasusBlock.js';
+import reviveCasusBlock from './reviveCasusBlock.js';
+
+// Creates a deep clone of this object.
+// This is helpful for copy-pasting purposes, for example
+function casusBlockDeepClone(toClone: CasusBlock): CasusBlock {
+	const asJSON=JSON.stringify(toClone);
+	const withoutMethods=JSON.parse(asJSON);
+	const revived=reviveCasusBlock(withoutMethods);
+	return revived;
+}
+
+export default casusBlockDeepClone;

--- a/src/casus/loadCasus.js
+++ b/src/casus/loadCasus.js
@@ -3,7 +3,7 @@
 import getLoginToken from '../globalComponents/getLoginToken.js';
 import getTankForCasus from '../globalComponents/getTankForCasus.js';
 import ContainerBlock from './blocks/ContainerBlock.js';
-import reviveCasusBlock from './reviveCasusBlock.js';
+import {reviveAsContainer} from './reviveCasusBlock.js';
 
 function loadCasus(onBlocksLoaded: (casusBlock: ContainerBlock) => void, tankId: ?string = null): void {
 	const targetTankId = tankId ?? getTankForCasus();
@@ -39,7 +39,7 @@ function loadCasus(onBlocksLoaded: (casusBlock: ContainerBlock) => void, tankId:
 					onBlocksLoaded(new ContainerBlock());
 					return;
 				}
-				let revived=reviveCasusBlock(tank.casusCode);
+				let revived=reviveAsContainer(tank.casusCode);
 				console.log('Recieved blocks.');
 				console.log(revived);
 				onBlocksLoaded(revived);

--- a/src/casus/reviveCasusBlock.js
+++ b/src/casus/reviveCasusBlock.js
@@ -405,4 +405,5 @@ function reviveCasusBlock(orig: SomeBlockFromServer): CasusBlock {
 	}
 }
 
-export default reviveAsContainer;
+export {reviveAsContainer};
+export default reviveCasusBlock;

--- a/src/tanks/TankLoader.js
+++ b/src/tanks/TankLoader.js
@@ -13,7 +13,7 @@ import TankPart from './TankPart.js';
 import loadCasus from '../casus/loadCasus.js';
 import BackendTank from './BackendTank.js';
 import type { TankComponent } from '../globalComponents/typesAndClasses/TankComponent.js';
-import reviveCasusBlock from '../casus/reviveCasusBlock.js';
+import {reviveAsContainer} from '../casus/reviveCasusBlock.js';
 
 function getTestTank(id: number=1): Tank {
 	const position=id===1?new Vec(-80, -40):new Vec(50, 40);
@@ -50,7 +50,7 @@ function getTank(tank: BackendTank): Tank {
 	const treads: TankComponent = tank.components[7];
 	const items: Array<TankComponent> = [tank.components[8], tank.components[9], tank.components[10]];
 	const revivedCasusCode: ContainerBlock = tank.casusCode!=null ? 
-		reviveCasusBlock(tank.casusCode) : 
+		reviveAsContainer(tank.casusCode) : 
 		new ContainerBlock();
 	
 	// Setup return value.


### PR DESCRIPTION
**Description**
Changed left-click to grab a contiguous block of casus blocks. It feels a little foreign to me now because I have been using the other system for a few weeks at this point, but if you guys don't like it, we can switch it back only selecting a single block by just changing a boolean, so that shouldn't be an issue.

You can also now copy an entire block and all its children by right-clicking on it. So that's pretty cool I think. It should massively speed up working with Casus I think. Here's kind of a sample of what that looks like:
![image](https://user-images.githubusercontent.com/18317476/78513185-d5ccbe00-7777-11ea-9423-d2dd41a711e5.png)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/78513197-eaa95180-7777-11ea-928d-039c86655902.png)


**Resolves These Issues**
Resolves #375 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
Go to the casus code for some tank.
Add some code that does whatever you feel like.
Right clicking on a block will now clone it.
Left clicking on a block will select that blocks and all blocks directly below it.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)