### PR TITLE
Fixed bug with blocks being destroyed on cancel

### DIFF
--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -190,7 +190,7 @@ class CasusEditor extends React.Component<Props, State> {
 	}
 
 	onCancelClicked() {
-		//delete variableblocktorename
+		//delete VariableBlockToRename
 		const block=this.state.variableBlockToRename;
 		if (block!=null) {
 			const toRemovePos=new Vec(block.boundingBox.x+1, block.boundingBox.y+1);

--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -190,12 +190,14 @@ class CasusEditor extends React.Component<Props, State> {
 	}
 
 	onCancelClicked() {
-		//delete variableBlockToRename
+		//delete variableblocktorename
 		const block=this.state.variableBlockToRename;
 		if (block!=null) {
 			const toRemovePos=new Vec(block.boundingBox.x+1, block.boundingBox.y+1);
-			//TODO: only remove the block if it was successfully placed!
-			this.state.containerBlock.removeBlockAt(toRemovePos, false, false);
+			const deepest = this.state.containerBlock.getDeepestChildContainingPoint(toRemovePos);
+			if (deepest === block) {
+				this.state.containerBlock.removeBlockAt(toRemovePos, false, false);
+			}
 		}
 
 		this.setState({variableBlockToRename: null});


### PR DESCRIPTION
**Description**
When you incorrectly place a block that needs to be renamed and then click cancel, there was previously a bug that caused whatever block you placed the block on to be destroyed. This PR fixes that. Here is a gif of it working as expected:
![NotDeleteingOnCancel](https://user-images.githubusercontent.com/18317476/78613404-d3cb3380-7839-11ea-82f5-5b59b2266d33.gif)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/78613569-315f8000-783a-11ea-9094-e6e705dd44dd.png)


**Resolves These Issues**
Resolves #388 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
Try misplacing some block that would cause the popup to appear, and then click cancel. Everything should work as you would expect ti to

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)