### PR TITLE
Added a much better debug system that doesn't crash the browser like console.log does

### DIFF
--- a/src/battleground/Battleground.css
+++ b/src/battleground/Battleground.css
@@ -1,4 +1,9 @@
 .battlegroundCanvas {
 	background-color: #fafafa;
-	width: 1300px; 
+	width: 1300px;
+}
+
+.battlegroundCanvasDiv {
+	width: 80%;	
+	display: inline-block;
 }

--- a/src/battleground/Battleground.js
+++ b/src/battleground/Battleground.js
@@ -17,6 +17,7 @@ import reportMatchResultAPICall from '../globalComponents/apiCalls/reportMatchRe
 
 type Props = {|
 	setPlayersTank: (Tank, Tank) => void,
+	addDebugLine: (string) => void,
 |};
 
 type MatchResult = 
@@ -119,7 +120,7 @@ class Battleground extends React.Component<Props> {
 
 	render(): React.Node {
 		return (
-			<div>
+			<div className="battlegroundCanvasDiv">
 				<canvas
 					className="battlegroundCanvas"
 					ref="canvas"
@@ -177,6 +178,10 @@ class Battleground extends React.Component<Props> {
 	_rerender(): void {
 		this._resizeCanvas();
 		const canvas: HTMLCanvasElement = this.refs.canvas;
+		if (canvas==null) {
+			console.log('warning: null canvas!');
+			return;
+		}
 		const ctx: CanvasRenderingContext2D = canvas.getContext('2d');
 		const drawer=new ImageDrawer(ctx);
 		drawer.fillBlackRect(1);
@@ -237,6 +242,10 @@ class Battleground extends React.Component<Props> {
 
 	_resizeCanvas(): void {
 		const canvas: HTMLCanvasElement = this.refs.canvas;
+		if (canvas==null) {
+			console.log('warning: null canvas!');
+			return;
+		}
 		const targetWidth=canvas.clientWidth;
 		const targetHeight=targetWidth/200*120;
 		if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
@@ -303,6 +312,10 @@ class Battleground extends React.Component<Props> {
 
 	deleteGameObject(toDelete: GameObject): void {
 		this.objectsToDelete.push(toDelete);
+	}
+
+	addDebugLine(line: string): void {
+		this.props.addDebugLine(line);
 	}
 
 }

--- a/src/battleground/Battleground.js
+++ b/src/battleground/Battleground.js
@@ -315,6 +315,11 @@ class Battleground extends React.Component<Props> {
 	}
 
 	addDebugLine(line: string): void {
+		if (this.matchIdToReport != null) {
+			// then this is an actual match against another real player, not a training
+			// match, so don't show any debug
+			return;
+		}
 		this.props.addDebugLine(line);
 	}
 

--- a/src/battleground/BattlegroundContainer.css
+++ b/src/battleground/BattlegroundContainer.css
@@ -1,7 +1,24 @@
 .battlegroundContainer {
+	width: 1625px;
+	display: block;
+	margin-left: auto;
+	margin-right: auto;
+
+}
+
+.debugAndBattleContainer {
+	width: 1625px;
+}
+
+.battlegroundContainerFull {
 	width: 1300px;
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
 
 }
+
+.debugAndBattleContainerFull {
+	width: 1300px;
+}
+

--- a/src/battleground/BattlegroundContainer.js
+++ b/src/battleground/BattlegroundContainer.js
@@ -5,6 +5,7 @@ import Battleground from './Battleground.js';
 import HealthBarsField from './HealthBarsField.js';
 import Navbar from '../globalComponents/Navbar.js';
 import Tank from '../tanks/Tank.js';
+import DebugLog from './DebugLog.js';
 
 import './BattlegroundContainer.css';
 
@@ -13,7 +14,10 @@ type Props = {||};
 type State = {
 	playerOneTank: ?Tank,
 	playerTwoTank: ?Tank,
+	debugLines: Array<string>,
 };
+
+const MAX_DEBUG_LINES=30;
 
 class BattlegroundContainer extends React.Component<Props, State> {
 
@@ -22,10 +26,18 @@ class BattlegroundContainer extends React.Component<Props, State> {
 		this.state={
 			playerOneTank: null,
 			playerTwoTank : null,
+			debugLines: [],
 		}
 	}
 
 	render(): React.Node {
+		const battleground=(
+			<Battleground 
+				setPlayersTank = {this.setPlayersTank}
+				addDebugLine = {this.addDebugLine}
+			/>
+		);
+		const haveDebug=this.state.debugLines.length!==0;
 		return (
 			<div>
 				<Navbar
@@ -33,14 +45,18 @@ class BattlegroundContainer extends React.Component<Props, State> {
 					returnName='Back to Battle Arena'
 					pageName='Battleground'
 				/>
-				<div className="battlegroundContainer">
+				<div className={haveDebug?'battlegroundContainer':'battlegroundContainerFull'}>
 					<HealthBarsField
 						playerOneTank = {this.state.playerOneTank}
 						playerTwoTank = {this.state.playerTwoTank}
 					/>
-					<Battleground 
-						setPlayersTank = {this.setPlayersTank}
-					/>
+					<div className={haveDebug?'debugAndBattleContainer':'debugAndBattleContainerFull'}>
+						{battleground}
+						{haveDebug?
+							<DebugLog debugLines={this.state.debugLines}/>:
+							<div></div>
+						}
+					</div>
 				</div>
 			</div>
 		);
@@ -50,6 +66,16 @@ class BattlegroundContainer extends React.Component<Props, State> {
 		this.setState({
 			playerOneTank: playerOneTank,
 			playerTwoTank: playerTwoTank
+		});
+	}
+
+	addDebugLine = (line: string): void => {
+		const newDebugLines=this.state.debugLines.concat(line);
+		while (newDebugLines.length>MAX_DEBUG_LINES) {
+			newDebugLines.shift();
+		}
+		this.setState({
+			debugLines: newDebugLines,
 		});
 	}
 }

--- a/src/battleground/BattlegroundContainer.js
+++ b/src/battleground/BattlegroundContainer.js
@@ -6,6 +6,7 @@ import HealthBarsField from './HealthBarsField.js';
 import Navbar from '../globalComponents/Navbar.js';
 import Tank from '../tanks/Tank.js';
 import DebugLog from './DebugLog.js';
+import getReturnToFromBattlegroundLink from './getReturnToFromBattlegroundLink.js';
 
 import './BattlegroundContainer.css';
 
@@ -37,12 +38,13 @@ class BattlegroundContainer extends React.Component<Props, State> {
 				addDebugLine = {this.addDebugLine}
 			/>
 		);
+		const returnTo=getReturnToFromBattlegroundLink();
 		const haveDebug=this.state.debugLines.length!==0;
 		return (
 			<div>
 				<Navbar
-					linkName='/BattleArena'
-					returnName='Back to Battle Arena'
+					linkName={returnTo}
+					returnName='Exit Early'
 					pageName='Battleground'
 				/>
 				<div className={haveDebug?'battlegroundContainer':'battlegroundContainerFull'}>

--- a/src/battleground/DebugLog.css
+++ b/src/battleground/DebugLog.css
@@ -5,3 +5,12 @@
 	height: 780px;
 	vertical-align: top;
 }
+
+.debugLogHeader {
+	padding: 10px;
+}
+
+.debugEntry {
+	padding-left: 10px;
+	padding-left: 30px;
+}

--- a/src/battleground/DebugLog.css
+++ b/src/battleground/DebugLog.css
@@ -1,0 +1,7 @@
+.debugLog {
+	display: inline-block;
+	background:#111111;
+	width: 20%;
+	height: 780px;
+	vertical-align: top;
+}

--- a/src/battleground/DebugLog.js
+++ b/src/battleground/DebugLog.js
@@ -1,0 +1,26 @@
+//@flow strict
+
+import * as React from 'react';
+
+import './DebugLog.css';
+
+type Props = {|
+	debugLines: Array<string>,
+|};
+
+class DebugLog extends React.Component<Props> {
+
+	render(): React.Node {
+		return (
+			<div className='debugLog'>
+				{this.props.debugLines.map((text, index) =>
+					<div key={index}>
+						{text}
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+
+export default DebugLog;

--- a/src/battleground/DebugLog.js
+++ b/src/battleground/DebugLog.js
@@ -13,8 +13,9 @@ class DebugLog extends React.Component<Props> {
 	render(): React.Node {
 		return (
 			<div className='debugLog'>
+				<h4 className='debugLogHeader'>Tank Printouts</h4>
 				{this.props.debugLines.map((text, index) =>
-					<div key={index}>
+					<div key={index} className="debugEntry">
 						{text}
 					</div>
 				)}

--- a/src/casus/blocks/PrintBlock.js
+++ b/src/casus/blocks/PrintBlock.js
@@ -2,6 +2,10 @@
 
 import UnaryOperationBlock from './UnaryOperationBlock.js';
 import type {DataType} from './DataType.js';
+import {getInterpriterState} from '../interpreter/InterpriterState.js';
+import IntValue from '../interpreter/IntValue.js';
+import BooleanValue from '../interpreter/BooleanValue.js';
+import DoubleValue from '../interpreter/DoubleValue.js';
 
 class PrintBlock extends UnaryOperationBlock {
 
@@ -11,7 +15,15 @@ class PrintBlock extends UnaryOperationBlock {
 
 	evaluate(): null {
 		const res=this.rChild.runEvaluate();
-		console.log(res);
+		if (res==null) {
+			throw new Error('Tried to print something that was null!');
+		}
+		if (res instanceof IntValue || res instanceof DoubleValue ) {
+			getInterpriterState().printDebugLine(res.val + '');
+		}
+		if (res instanceof BooleanValue) {
+			getInterpriterState().printDebugLine(res.val ? 'true': 'false');
+		}
 		return null;
 	}
 }

--- a/src/casus/interpreter/InterpriterState.js
+++ b/src/casus/interpreter/InterpriterState.js
@@ -38,6 +38,8 @@ class InterpriterState {
 
 	statementsMade: number;
 	recursionDepth: number;
+
+	printedStatements: Array<string>;
 	
 	constructor() {
 		this.intVariables = new Map<string, IntValue>();
@@ -141,6 +143,14 @@ class InterpriterState {
 
 	resetStatementsMade(): void {
 		this.statementsMade = 0;
+	}
+
+	printDebugLine(toPrint: string): void {
+		this.printedStatements.push(toPrint);
+	}
+
+	resetDebug(): void {
+		this.printedStatements =  [];
 	}
 }
 

--- a/src/tanks/Tank.js
+++ b/src/tanks/Tank.js
@@ -167,15 +167,19 @@ class Tank extends GameObject {
 			}
 			return;
 		}
-		this.executeCasusFrame();	
+		this.executeCasusFrame(battleground);	
 		this.executePhysics(battleground.getCollisionSegs(), battleground.getTanks(), battleground);
 	}
 
-	executeCasusFrame(): void {
+	executeCasusFrame(battleground: Battleground): void {
 		this.interpriterState.resetStatementsMade();
+		this.interpriterState.resetDebug();
 		setInterpriterState(this.interpriterState);	
 		this.casusCode.runEvaluate();
 		this.interpriterState = getInterpriterState();
+		for (const debugLine of this.interpriterState.printedStatements) {
+			battleground.addDebugLine(' '+this.tankName+': '+debugLine);
+		}
 	}
 	
 	executePhysics(walls: Array<Seg>, tanks: Array<Tank>, battleground: Battleground): void {


### PR DESCRIPTION
**Description**
Previously to log debug statements, we were just printing them to the JS console. This was obviously not at all user friendly, and had the annoying side effect of crashing the user's browser if you logged way too many things (because the browser would stored all of the logged messages in memory). This is now fixed so that there is a (pretty nice) system that displays logged messages on the side of the screen. It looks like this:
![image](https://user-images.githubusercontent.com/18317476/78723053-b7da9700-78f8-11ea-8b7e-a5e2fad1448b.png)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/78723374-4ea75380-78f9-11ea-93c4-e40f73dc513e.png)


**Resolves These Issues**
Resolves #373 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [x] This change requires a update in the design document (if applicable)