### PR TITLE
Updates to daily wager stipend and implemented first win of day streaks.

### DIFF
--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -186,16 +186,8 @@ exports.reportResults = async (req: Request, res: Response) => {
 			const newUserOneElo = eloRating.ifTies(userOne.stats.elo, userTwo.stats.elo);
 			const newUserTwoElo = eloRating.ifTies(userTwo.stats.elo, userOne.stats.elo);
 			
-			// We want eloExchanged to be a positive value so we take whoever's increased and subtract 
-			if (userOne.stats.elo > userTwo.stats.elo) {
-				const eloExchanged = userOne.stats.elo - newUserOneElo;
-				battle.eloExchanged = eloExchanged;
-			} else {
-				const eloExchanged = userTwo.stats.elo - newUserTwoElo;
-				battle.eloExchanged = eloExchanged;
-
-			}
-			
+			// Record elo exchanged on tie
+			battle.eloExchanged = Math.abs(userOne.stats.elo-newUserOneElo);			
 
 			userOne.stats.elo = newUserOneElo;
 			userTwo.stats.elo = newUserTwoElo;

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -234,11 +234,11 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userOne.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 2 Bonus");					
 				}
-				else if (userOne.stats.firstWinOfDayStreak === 2) {
-					// +300 for third day of the streak, and streak resets
+				else {
+					// +300 for third day of the streak onward.
 					userOne.money += (battle.prizeMoney + 300);
-					userOne.stats.firstWinOfDayStreak = 0;
-					console.log("Given First Win of Day 3 Bonus. Resetting streak.");					
+					userOne.stats.firstWinOfDayStreak++;
+					console.log("Given First Win of Day 3+ Bonus.");					
 				}
 				// Set lastFirstWindOfDay
 				userOne.stats.lastFirstWinOfDay = new Date();
@@ -317,11 +317,11 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userTwo.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 2 Bonus");					
 				}
-				else if (userTwo.stats.firstWinOfDayStreak === 2) {
-					// +300 for third day of the streak, and streak resets
+				else {
+					// +300 for third day of the streak onward
 					userTwo.money += (battle.prizeMoney + 300);
-					userTwo.stats.firstWinOfDayStreak = 0;
-					console.log("Given First Win of Day 3 Bonus. Resetting streak.");					
+					userTwo.stats.firstWinOfDayStreak++;
+					console.log("Given First Win of Day 3+ Bonus.");					
 				}
 				// Set lastFirstWindOfDay
 				userTwo.stats.lastFirstWinOfDay = new Date();

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -248,6 +248,8 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userOne.stats.firstWinOfDayStreak = 0;
 					console.log("Given First Win of Day 3 Bonus. Resetting streak.");					
 				}
+				// Set lastFirstWindOfDay
+				userOne.stats.lastFirstWinOfDay = new Date();
 			}
 			// Update stats
 			userOne.stats.wins += 1;
@@ -329,6 +331,8 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userTwo.stats.firstWinOfDayStreak = 0;
 					console.log("Given First Win of Day 3 Bonus. Resetting streak.");					
 				}
+				// Set lastFirstWindOfDay
+				userTwo.stats.lastFirstWinOfDay = new Date();
 			}
 			// Update stats
 			userTwo.stats.wins += 1;

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -496,6 +496,13 @@ exports.setWager = async (req: Request, res: Response) => {
 				.status(400)
 				.json({ msg: 'User does not have enough money'});
 		}
+
+		if (req.body.wager < 50) {
+			console.error('User cannot have a wager lower than 50');
+			return res
+				.status(400)
+				.json({ msg: 'User cannot have a wager lower than 50'});			
+		}
 		else {
 			// change wager amount and take that money from their balance
 			const take = user.money - req.body.wager;

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -479,10 +479,10 @@ exports.setWager = async (req: Request, res: Response) => {
 
 		// If a user has never made a wager or its been 24hrs since last stipend give them their stipend and update wagerDate
 		if (user.wagerDate == null || (new Date - user.wagerDate) > aDay) {
-			const newBalance = user.money + 5000;
+			const newBalance = user.money + 100;
 			user.money = newBalance;
 			user.wagerDate = new Date();
-			console.log('Applied stipend');
+			console.log('Applied daily wager stipend');
 		}
 		
 		// Add back the balance of the original wager

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -478,10 +478,11 @@ exports.setWager = async (req: Request, res: Response) => {
 		const aDay = 60 * 60 * 24 * 1000;
 
 		// If a user has never made a wager or its been 24hrs since last stipend give them their stipend and update wagerDate
-		if (user.wagerDate == null || (new Date() - user.wagerDate) > aDay) {
+		const now = new Date();
+		if (user.wagerDate == null || (now - user.wagerDate) > aDay) {
 			const newBalance = user.money + 100;
 			user.money = newBalance;
-			user.wagerDate = new Date();
+			user.wagerDate = now;
 			console.log('Applied daily wager stipend');
 		}
 		

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -478,7 +478,7 @@ exports.setWager = async (req: Request, res: Response) => {
 		const aDay = 60 * 60 * 24 * 1000;
 
 		// If a user has never made a wager or its been 24hrs since last stipend give them their stipend and update wagerDate
-		if (user.wagerDate == null || (new Date - user.wagerDate) > aDay) {
+		if (user.wagerDate == null || (new Date() - user.wagerDate) > aDay) {
 			const newBalance = user.money + 100;
 			user.money = newBalance;
 			user.wagerDate = new Date();

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -419,6 +419,15 @@ const User = new Mongoose.model('User', new Mongoose.Schema ({
         elo: {
             type: Number,
             default: 0
+        },
+        // Fields for first daily win streak goes up to 3 days 
+        firstWinOfDayStreak: {
+            type: Number,
+            default: 0
+        },
+        lastFirstWinOfDay: {
+            type: Date,
+            default: null
         }
     },
     // Records date/time when user was created.

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -30,7 +30,7 @@ const User = new Mongoose.model('User', new Mongoose.Schema ({
     // User starts with 50000 money by default. This can be changed as needed
     money: {
         type: Number,
-        default: 50000
+        default: 1000
     },
     wager: {
         type: Number,


### PR DESCRIPTION
**Description**
Lowered daily wager stipend to 100 from 5000.
Implemented First Win Of Day (FWOD) Bonus mechanic:
- Checks if it's your very first FWOD or if it's been a day since your last FWOD.
- Streak Bonuses
  - Day 1 FWOD Bonus: 100
  - Day 2 FWOD Bonus: 200
  - Day 3 FWOD Bonus: 300
- Streaks reset after Day 3 Bonus
- If it's been more than 2 days since your last FWOD, your streak is reset.
- Losses and ties before or between them don't affect the streak.
- Added fields to userModel to support FWOD mechanic.

**Resolves These Issues**
Resolves #274 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Logon to Fortuna and battle someone and win.
2. Confirm your winnings include Day 1 FWOD bonus.
3. Repeat 1-2 in increments of a day (or manually change it) and confirm the Day 2 and Day 3 bonuses are applied on your first win of the day.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [x] This change requires a update in the design document (if applicable)