### PR TITLE
Updated unfavoriteTank API to handle setting wager to 0

### DIFF
--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -66,7 +66,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 			return;
 		}
 		else if (this.state.userWager < 50) {
-			toast.error('Wager cannot be 0.');
+			toast.error('Wager cannot be less than 50.');
 			return;
 		}
 

--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -83,13 +83,9 @@ class SetWagerPopup extends React.Component<Props, State> {
 
 	// Remove the user's wager and favorite tank.
 	handleRemoveClick(): void {
-		setWager(0, setSuccessful => {
-			this.setState({currentWager: 0});
-			// Update user currency in the navbar.
-			this.props.onWagerUpdate();
-		});
 		removeFavoriteTankId(() => {
-			this.setState({removeWagerOpen: false, currentWagerTank: null});
+			this.setState({removeWagerOpen: false, currentWagerTank: null, currentWager: 0});
+			this.props.onWagerUpdate();
 		});
 	}
 

--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -65,7 +65,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 			toast.error('Not enough currency.');
 			return;
 		}
-		else if (this.state.userWager <= 0) {
+		else if (this.state.userWager < 50) {
 			toast.error('Wager cannot be 0.');
 			return;
 		}

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -93,19 +93,19 @@ exports.unfavoriteTank = async (req: Request, res: Response) => {
 	}
 
 	// Find the user and set favoriteTank to null.
-	await User.findOneAndUpdate( {_id: req.user.id }, {favoriteTank : null }, {new : true}, (err: Error, foundUser: User) => {
+	await User.findOneAndUpdate( {_id: req.user.id }, {favoriteTank : null, wager : 0 }, {new : true}, (err: Error, foundUser: User) => {
 		if (err) {
 			console.error(err.message);
 			
 			return res
 				.status(500)
-				.json({ msg: 'Could not set favoriteTank to null'});
+				.json({ msg: 'Could not set favorite tank to null or wager to 0'});
 		}
 		else {
 			console.log('favoriteTank removed');
 			return res
 				.status(200)
-				.json({ msg: 'Favorite tank removed' });
+				.json({ msg: 'Favorite tank removed and wager is 0' });
 		}
 	});
 }

--- a/src/backend/routes/tankRoutes.js
+++ b/src/backend/routes/tankRoutes.js
@@ -27,7 +27,7 @@ router.patch('/favoriteTank', [
         check('favoriteTank', 'A valid MongoId is required.').isMongoId()
     ], auth, tankController.favoriteTank);
 
-// Remove a favorite tank
+// Sets favorite tank to null and wager to 0
 // Route call: /unfavoriteTank
 // Header: x-auth-token
 // Body: N/A


### PR DESCRIPTION
**Description**
This bypasses the limitation on setting the wager to less than 50 by moving the remove wager to another API call. Also, I put the front end handling of a wager less than 50.

**Resolves These Issues**
Resolves #417 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Make a wager.
2. Remove your wager.
3. Ensure no errors popup and that the db confirms the update to wager and favorite tank.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)