### PR TITLE
Toast messages for dailys

### DIFF
--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -71,7 +71,10 @@ class SetWagerPopup extends React.Component<Props, State> {
 		}
 
 		// Check if the wager was set. Close the popup if it is.
-		setWager(this.state.userWager, () => {
+		setWager(this.state.userWager, stipendApplied => {
+			if (stipendApplied) {
+				toast.success('$100 added for setting your daily wager!');
+			}
 			this.setState({currentWager: this.state.userWager});
 			// Update user currency in the navbar.
 			this.props.onWagerUpdate();
@@ -126,12 +129,9 @@ class SetWagerPopup extends React.Component<Props, State> {
 				<label>Current Wager:&emsp;</label>
 				<label>{this.state.currentWagerTank == null ?
 					'No set wager tank' : 
-					<div className="wagerTank">
-						{this.state.currentWagerTank.tankName + ' '} 
-						<label>
-							for {this.state.currentWager}
-						</label>
-					</div>
+					<label>
+						{this.state.currentWagerTank.tankName + ' for ' + this.state.currentWager}
+					</label>
 				}</label>
 				<div className="wagerPopup">
 					<Popup 

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -279,7 +279,7 @@ exports.reportResults = async (req: Request, res: Response) => {
 	try {
 		const battle = await BattleRecord.findById(battleId);
 		// Tracks which user got the stipend for the first win of the day.
-		let bonusUser = 0;
+		let bonusAdded = 0;
 
 		if (battle == null) {
 			console.log('battle not found');
@@ -364,21 +364,21 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userOne.money += (battle.prizeMoney + 100);
 					userOne.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 1 Bonus");
-					bonusUser = 1;
+					bonusAdded = 100;
 				}
 				else if (userOne.stats.firstWinOfDayStreak === 1) {
 					// +200 for second day of the streak
 					userOne.money += (battle.prizeMoney + 200);
 					userOne.stats.firstWinOfDayStreak++;
-					console.log("Given First Win of Day 2 Bonus");	
-					bonusUser = 1;				
+					console.log("Given First Win of Day 2 Bonus");
+					bonusAdded = 200;			
 				}
 				else {
 					// +300 for third day of the streak onward.
 					userOne.money += (battle.prizeMoney + 300);
 					userOne.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 3+ Bonus.");
-					bonusUser = 1;					
+					bonusAdded = 300;				
 				}
 				// Set lastFirstWindOfDay
 				userOne.stats.lastFirstWinOfDay = new Date();
@@ -414,17 +414,11 @@ exports.reportResults = async (req: Request, res: Response) => {
 			await userTwo.save();
 
 			// Check for if the logged in user got a first win of the day.
-			if (bonusUser === 1 && req.user.id === userOne.id) {
+			if (bonusAdded > 0 && req.user.id === userOne.id) {
 				console.log('Battlerecord complete');
 				return res
 					.status(200)
-					.json({ msg: 'First win of the day!' });
-			}
-			else if (bonusUser === 2 && req.user.id === userTwo.id) {
-				console.log('Battlerecord complete');
-				return res
-					.status(200)
-					.json({ msg: 'First win of the day!' });
+					.json({ msg: 'First win of the day, day ' + userOne.stats.firstWinOfDayStreak + ' $' + bonusAdded + ' added!' });
 			}
 		}
 		else if (winner === 2) { // userTwo victory
@@ -464,21 +458,21 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userTwo.money += (battle.prizeMoney + 100);
 					userTwo.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 1 Bonus");
-					bonusUser = 2;
+					bonusAdded = 100;
 				}
 				else if (userTwo.stats.firstWinOfDayStreak === 1) {
 					// +200 for second day of the streak
 					userTwo.money += (battle.prizeMoney + 200);
 					userTwo.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 2 Bonus");
-					bonusUser = 2;					
+					bonusAdded = 200;				
 				}
 				else {
 					// +300 for third day of the streak onward
 					userTwo.money += (battle.prizeMoney + 300);
 					userTwo.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 3+ Bonus.");
-					bonusUser = 2;					
+					bonusAdded = 300;				
 				}
 				// Set lastFirstWindOfDay
 				userTwo.stats.lastFirstWinOfDay = new Date();
@@ -503,18 +497,12 @@ exports.reportResults = async (req: Request, res: Response) => {
 			await userOne.save();
 			await userTwo.save();
 			
-			// Check for if the logged in user got a first win of the day.
-			if (bonusUser === 1 && req.user.id === userOne.id) {
+			// Check if the logged in user got their first win.
+			if (bonusAdded > 0 && req.user.id === userTwo.id) {
 				console.log('Battlerecord complete');
 				return res
 					.status(200)
-					.json({ msg: 'First win of the day!' });
-			}
-			else if (bonusUser === 2 && req.user.id === userTwo.id) {
-				console.log('Battlerecord complete');
-				return res
-					.status(200)
-					.json({ msg: 'First win of the day!' });
+					.json({ msg: 'First win of the day, day ' + userTwo.stats.firstWinOfDayStreak + ' $' + bonusAdded + ' added!' });
 			}
 		}
 		else { // Invalid victor
@@ -524,11 +512,12 @@ exports.reportResults = async (req: Request, res: Response) => {
 				.json({ msg: 'Bad Request'});
 		}
 
+
 		console.log('All documents updated successfully! BattleRecord complete');
 		return res
 			.status(200)
 			.send(battle);
-
+		
 	} catch (err) {
 		console.error('Update failed')
 		return res

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -1,7 +1,6 @@
 // @flow strict
 
 import type { Request, Response } from 'express';
-import { toast } from 'react-toastify';
 
 const { validationResult } = require('express-validator');
 

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -98,7 +98,7 @@ exports.prepareMatch1v1 = async (req: Request, res: Response) => {
 			eloExchanged: 0
 		});
 
-		if (Math.random()<0.5)) {
+		if (Math.random()<0.5) {
 			newRecord.map = 'DIRT';
 		} else {
 			newRecord.map = 'HEX';
@@ -224,7 +224,7 @@ exports.prepareMatch3v3 = async (req: Request, res: Response) => {
 			eloExchanged: 0
 		});
 		
-		if (Math.random()<0.5)) {
+		if (Math.random()<0.5) {
 			newRecord.map = 'CANDEN';
 		} else {
 			newRecord.map = 'LUNAR';

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -277,6 +277,8 @@ exports.reportResults = async (req: Request, res: Response) => {
 
 	try {
 		const battle = await BattleRecord.findById(battleId);
+		// Tracks which user got the stipend for the first win of the day.
+		let bonusUser = 0;
 
 		if (battle == null) {
 			console.log('battle not found');
@@ -348,7 +350,6 @@ exports.reportResults = async (req: Request, res: Response) => {
 			// Update money with first win of day bonus, if applicable
 			const aDay = 60 * 60 * 24 * 1000;
 			const compare = (!userOne.stats.lastFirstWinOfDay) ? (new Date() - userOne.stats.lastFirstWinOfDay) : 0;
-			let bonusUser = 0;
 			// If last recorded first win of the day is null or it's been over a day since
 			if (userOne.stats.lastFirstWinOfDay == null || compare > aDay) {
 				// If it's been over 2 days since, the streak is broken
@@ -410,6 +411,20 @@ exports.reportResults = async (req: Request, res: Response) => {
 			await battle.save();
 			await userOne.save();
 			await userTwo.save();
+
+			// Check for if the logged in user got a first win of the day.
+			if (bonusUser === 1 && req.user.id === userOne.id) {
+				console.log('Battlerecord complete');
+				return res
+					.status(200)
+					.json({ msg: 'First win of the day!' });
+			}
+			else if (bonusUser === 2 && req.user.id === userTwo.id) {
+				console.log('Battlerecord complete');
+				return res
+					.status(200)
+					.json({ msg: 'First win of the day!' });
+			}
 		}
 		else if (winner === 2) { // userTwo victory
 			// Update money and losses for user one
@@ -486,17 +501,17 @@ exports.reportResults = async (req: Request, res: Response) => {
 			await battle.save();
 			await userOne.save();
 			await userTwo.save();
-
-			console.log(req.user.id);
-			console.log(userOne.id);
-			console.log(userTwo.id);
+			
+			// Check for if the logged in user got a first win of the day.
 			if (bonusUser === 1 && req.user.id === userOne.id) {
-				return
+				console.log('Battlerecord complete');
+				return res
 					.status(200)
 					.json({ msg: 'First win of the day!' });
 			}
 			else if (bonusUser === 2 && req.user.id === userTwo.id) {
-				return
+				console.log('Battlerecord complete');
+				return res
 					.status(200)
 					.json({ msg: 'First win of the day!' });
 			}

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -1,6 +1,7 @@
 // @flow strict
 
 import type { Request, Response } from 'express';
+import { toast } from 'react-toastify';
 
 const { validationResult } = require('express-validator');
 
@@ -214,12 +215,13 @@ exports.reportResults = async (req: Request, res: Response) => {
 			// Update money with first win of day bonus, if applicable
 			const aDay = 60 * 60 * 24 * 1000;
 			const compare = (!userOne.stats.lastFirstWinOfDay) ? (new Date() - userOne.stats.lastFirstWinOfDay) : 0;
+			let bonusUser = 0;
 			// If last recorded first win of the day is null or it's been over a day since
 			if (userOne.stats.lastFirstWinOfDay == null || compare > aDay) {
 				// If it's been over 2 days since, the streak is broken
 				if (compare > (aDay*2)) {
 					userOne.stats.firstWinOfDayStreak = 0;
-					console.log("Streak Broken :(");	
+					console.log("Streak Broken :(");
 				}
 				// Give bonus based on current streak
 				if (userOne.stats.firstWinOfDayStreak === 0) {
@@ -227,18 +229,21 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userOne.money += (battle.prizeMoney + 100);
 					userOne.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 1 Bonus");
+					bonusUser = 1;
 				}
 				else if (userOne.stats.firstWinOfDayStreak === 1) {
 					// +200 for second day of the streak
 					userOne.money += (battle.prizeMoney + 200);
 					userOne.stats.firstWinOfDayStreak++;
-					console.log("Given First Win of Day 2 Bonus");					
+					console.log("Given First Win of Day 2 Bonus");	
+					bonusUser = 1;				
 				}
 				else {
 					// +300 for third day of the streak onward.
 					userOne.money += (battle.prizeMoney + 300);
 					userOne.stats.firstWinOfDayStreak++;
-					console.log("Given First Win of Day 3+ Bonus.");					
+					console.log("Given First Win of Day 3+ Bonus.");
+					bonusUser = 1;					
 				}
 				// Set lastFirstWindOfDay
 				userOne.stats.lastFirstWinOfDay = new Date();
@@ -310,18 +315,21 @@ exports.reportResults = async (req: Request, res: Response) => {
 					userTwo.money += (battle.prizeMoney + 100);
 					userTwo.stats.firstWinOfDayStreak++;
 					console.log("Given First Win of Day 1 Bonus");
+					bonusUser = 2;
 				}
 				else if (userTwo.stats.firstWinOfDayStreak === 1) {
 					// +200 for second day of the streak
 					userTwo.money += (battle.prizeMoney + 200);
 					userTwo.stats.firstWinOfDayStreak++;
-					console.log("Given First Win of Day 2 Bonus");					
+					console.log("Given First Win of Day 2 Bonus");
+					bonusUser = 2;					
 				}
 				else {
 					// +300 for third day of the streak onward
 					userTwo.money += (battle.prizeMoney + 300);
 					userTwo.stats.firstWinOfDayStreak++;
-					console.log("Given First Win of Day 3+ Bonus.");					
+					console.log("Given First Win of Day 3+ Bonus.");
+					bonusUser = 2;					
 				}
 				// Set lastFirstWindOfDay
 				userTwo.stats.lastFirstWinOfDay = new Date();
@@ -345,6 +353,20 @@ exports.reportResults = async (req: Request, res: Response) => {
 			await battle.save();
 			await userOne.save();
 			await userTwo.save();
+
+			console.log(req.user.id);
+			console.log(userOne.id);
+			console.log(userTwo.id);
+			if (bonusUser === 1 && req.user.id === userOne.id) {
+				return
+					.status(200)
+					.json({ msg: 'First win of the day!' });
+			}
+			else if (bonusUser === 2 && req.user.id === userTwo.id) {
+				return
+					.status(200)
+					.json({ msg: 'First win of the day!' });
+			}
 		}
 		else { // Invalid victor
 			console.error('Number not expected: please enter either 0 in the event of a tie, 1 in the event the personBeingChallenged is the victor, or 2 in the event the challenger is the victor');

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -106,6 +106,7 @@ exports.unfavoriteTank = async (req: Request, res: Response) => {
 	const addBack = user.money + user.wager;
 	user.money = addBack;
 	user.favoriteTank = null;
+	user.wager = 0;
 
 	await user.save();
 

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -93,21 +93,26 @@ exports.unfavoriteTank = async (req: Request, res: Response) => {
 	}
 
 	// Find the user and set favoriteTank to null.
-	await User.findOneAndUpdate( {_id: req.user.id }, {favoriteTank : null, wager : 0 }, {new : true}, (err: Error, foundUser: User) => {
-		if (err) {
-			console.error(err.message);
-			
-			return res
-				.status(500)
-				.json({ msg: 'Could not set favorite tank to null or wager to 0'});
-		}
-		else {
-			console.log('favoriteTank removed');
-			return res
-				.status(200)
-				.json({ msg: 'Favorite tank removed and wager is 0' });
-		}
-	});
+	const user = await User.findById(req.user.id, 'wager money favoriteTank');
+
+	// Check if found.
+	if (user == null) {
+		console.log('Could not find user in DB');
+		return res
+			.status(404)
+			.json({ msg: 'Could not find user in db'});
+	}
+
+	const addBack = user.money + user.wager;
+	user.money = addBack;
+	user.favoriteTank = null;
+
+	await user.save();
+
+	console.log('Favorite tank removed and wager is 0');
+	return res
+		.status(200)
+		.json({ msg: 'Favorite tank removed and wager is 0' });
 }
 
 exports.userTanks = async (req: Request, res: Response) => {

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -219,21 +219,27 @@ exports.unfavoriteTankTeam = async (req: Request, res: Response) => {
 	}
 
 	// Find the user and set favoriteTank to null.
-	await User.findOneAndUpdate( {_id: req.user.id }, {favoriteTanks : [], wager : 0 }, {new : true}, (err: Error, foundUser: User) => {
-		if (err) {
-			console.error(err.message);
-			
-			return res
-				.status(500)
-				.json({ msg: 'Could not set favorite tanks to [] or wager to 0'});
-		}
-		else {
-			console.log('favoriteTanks removed');
-			return res
-				.status(200)
-				.json({ msg: 'Favorite tanks removed and wager is 0' });
-		}
-	});
+	const user = await User.findById(req.user.id, 'wager money favoriteTanks');
+
+	// Check if found.
+	if (user == null) {
+		console.log('Could not find user in DB');
+		return res
+			.status(404)
+			.json({ msg: 'Could not find user in db'});
+	}
+
+	const addBack = user.money + user.wager;
+	user.money = addBack;
+	user.favoriteTanks = [];
+	user.wager = 0;
+
+	await user.save();
+
+	console.log('Favorite tank removed and wager is 0');
+	return res
+		.status(200)
+		.json({ msg: 'Favorite tank removed and wager is 0' });
 }
 
 exports.userTanks = async (req: Request, res: Response) => {

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -522,7 +522,7 @@ exports.setWager = async (req: Request, res: Response) => {
 			else {
 				console.log('Wager updated and stipend added');
 				return res
-					.status(200)
+					.status(201)
 					.send(user);
 			}
 		}

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -479,8 +479,9 @@ exports.setWager = async (req: Request, res: Response) => {
 
 		// If a user has never made a wager or its been 24hrs since last stipend give them their stipend and update wagerDate
 		const now = new Date();
+		let newBalance = 0;
 		if (user.wagerDate == null || (now - user.wagerDate) > aDay) {
-			const newBalance = user.money + 100;
+			newBalance = user.money + 100;
 			user.money = newBalance;
 			user.wagerDate = now;
 			console.log('Applied daily wager stipend');
@@ -508,15 +509,22 @@ exports.setWager = async (req: Request, res: Response) => {
 			// change wager amount and take that money from their balance
 			const take = user.money - req.body.wager;
 			user.money = take;
-
 			user.wager = req.body.wager;
 
 			await user.save();
 
-			console.log('Wager successfully updated');
-			return res
-				.status(200)
-				.send(user);
+			if (newBalance === 0) {
+				console.log('Wager successfully updated');
+				return res
+					.status(200)
+					.send(user);
+			}
+			else {
+				console.log('Wager updated and stipend added');
+				return res
+					.status(200)
+					.send(user);
+			}
 		}
 	} catch (err) {
 		console.error(err.message);

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -479,11 +479,12 @@ exports.setWager = async (req: Request, res: Response) => {
 
 		// If a user has never made a wager or its been 24hrs since last stipend give them their stipend and update wagerDate
 		const now = new Date();
-		let newBalance = 0;
+		let stipendAdded = false
 		if (user.wagerDate == null || (now - user.wagerDate) > aDay) {
-			newBalance = user.money + 100;
+			const newBalance = user.money + 100;
 			user.money = newBalance;
 			user.wagerDate = now;
+			stipendAdded = true;
 			console.log('Applied daily wager stipend');
 		}
 		
@@ -513,16 +514,16 @@ exports.setWager = async (req: Request, res: Response) => {
 
 			await user.save();
 
-			if (newBalance === 0) {
-				console.log('Wager successfully updated');
-				return res
-					.status(200)
-					.send(user);
-			}
-			else {
+			if (stipendAdded) {
 				console.log('Wager updated and stipend added');
 				return res
 					.status(201)
+					.send(user);
+			}
+			else {
+				console.log('Wager successfully updated');
+				return res
+					.status(200)
 					.send(user);
 			}
 		}

--- a/src/battlearena/Replays.js
+++ b/src/battlearena/Replays.js
@@ -77,7 +77,7 @@ class Replays extends React.Component<Props, State> {
 									<td>{this.getWinner(replay)}</td>
 									<td><button className="reallySmallBtn" onClick={() => this.watchReplay(replay)}>View</button></td>
 									<td>{replay.prizeMoney}</td>
-									<td>{(this.getWinner(replay) !== this.state.myUsername) ? '-' + replay.eloExchanged : '+' + replay.eloExchanged}</td>
+									<td>{replay.eloExchanged}</td>
 								</tr>
 							)}
 						</tbody>

--- a/src/battleground/Battleground.js
+++ b/src/battleground/Battleground.js
@@ -17,6 +17,7 @@ import reportMatchResultAPICall from '../globalComponents/apiCalls/reportMatchRe
 import getBattlegroundArena from './getBattlegroundArena.js';
 import getBattlegroundWidth from './getBattlegroundWidth.js';
 import getBattlegroundHeight from './getBattlegroundHeight.js';
+import { ToastContainer } from 'react-toastify';
 
 import type {ArenaType} from './ArenaType.js';
 import type {ImageName} from './ImageName.js';
@@ -189,6 +190,7 @@ class Battleground extends React.Component<Props> {
 					className="battlegroundCanvas"
 					ref="canvas"
 				/>
+				<ToastContainer />
 			</div>
 		);
 	}

--- a/src/globalComponents/apiCalls/reportMatchResultAPICall.js
+++ b/src/globalComponents/apiCalls/reportMatchResultAPICall.js
@@ -29,6 +29,9 @@ function reportMatchResultAPICall(winner: 0|1|2, matchId: string) {
 			}
 			else {
 				console.log('successfully logged result of match.');
+				if (getErrorFromObject(data) === 'First win of the day!') {
+					toast.success('First win of the day bonus added!');
+				}
 			}
 		})
 	);

--- a/src/globalComponents/apiCalls/reportMatchResultAPICall.js
+++ b/src/globalComponents/apiCalls/reportMatchResultAPICall.js
@@ -29,8 +29,8 @@ function reportMatchResultAPICall(winner: 0|1|2, matchId: string) {
 			}
 			else {
 				console.log('successfully logged result of match.');
-				if (getErrorFromObject(data) === 'First win of the day!') {
-					toast.success('First win of the day bonus added!');
+				if (getErrorFromObject(data) !== '') {
+					toast.success(getErrorFromObject(data));
 				}
 			}
 		})

--- a/src/globalComponents/apiCalls/userAPIIntegration.js
+++ b/src/globalComponents/apiCalls/userAPIIntegration.js
@@ -7,7 +7,7 @@ import getErrorFromObject from '../getErrorFromObject.js';
 
 // Sets the user's wager according to the number passed to it.
 // Returns a boolean indicating success (true) or failure (false). Maybe change to string to return the error.
-function setWager(wager: number, onLoad:() => void): void {
+function setWager(wager: number, onLoad:(stipendApplied: boolean) => void): void {
 	const responsePromise: Promise<Response> = fetch('/api/user/setWager/', {
 		method: 'PATCH',
 		headers: {
@@ -20,13 +20,16 @@ function setWager(wager: number, onLoad:() => void): void {
 	});
 	responsePromise.then (
 		response => response.json().then(data => {
-			if (response.status !== 200) {
+			if (response.status !== 200 && response.status !== 201) {
 				console.log(response.status);
 				console.log(data);
 				toast.error(getErrorFromObject(data));
 			}
-			else {
-				onLoad();
+			else if (response.status === 200) {
+				onLoad(false);
+			}
+			else if (response.status === 201) {
+				onLoad(true);
 			}
 		})
 	);


### PR DESCRIPTION
**Description**
Whenever a user gets a daily stipend (through winning or setting their wager) a toast pops up and informs them. Also, in this branch is a fix for the wager not being taken away from user currency when wagering and a small replay table update.

**Resolves These Issues**
Resolves #(replace parentheses and the stuff here with the issue number, if there isn't one, create one.) 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Set a wager on a user that has not set a wager in the last 24 hours.
2. View toast.
3. Get a victory (ask David or I for code to have a tank win vs a sitting duck style tank).
4. View toast.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)