### PR TITLE
Fixed tank constructor to only start with the items it actually has

### DIFF
--- a/src/tanks/Tank.js
+++ b/src/tanks/Tank.js
@@ -124,7 +124,6 @@ class Tank extends GameObject {
 		tankName: string,
 		_id: string,
 		userId: string,
-		
 	) {
 		super(position);
 
@@ -147,15 +146,36 @@ class Tank extends GameObject {
 		this.interpriterState = new InterpriterState();
 		this.casusCode = casusCode;
 		this.rotation = Math.PI*0.5;
-		this.haveC4 = true; //TODO: remove this, it is just for testing...
-		this.minesLeft = 2; //TODO: remove this, for testing...
 		this.usedMineLastFrame = false;
-		this.haveNitroRepair = true; //TODO: remove this, for testing...
 		this.nitroRepairTimerLeft = 0;
-		this.haveOverdrive = true; //TODO: remove this, just for testing...
 		this.overdriveTimerLeft = 0;
-		this.haveMissileTracker = true; //TODO: remove this, just for testing...
 		this.health = this._getArmorOffset();
+
+
+		//process onetimeitems from items passed into constructor
+		this.haveC4 = false; 
+		this.minesLeft = 0;
+		this.haveNitroRepair = false;
+		this.haveOverdrive = false;
+		this.haveMissileTracker = false;
+		for (const itemPart of [itemOne, itemTwo, itemThree]) {
+			if (itemPart.name === 'mine') {
+				this.minesLeft++;
+			}
+			else if (itemPart.name === 'c4') {
+				this.haveC4 = true;
+			}
+			else if (itemPart.name === 'overdrive') {
+				this.haveOverdrive = true;
+			}
+			else if (itemPart.name === 'nitroRepair') {
+				this.haveNitroRepair = true;
+			}
+			else if (itemPart.name === 'missileTrackingBeacon') {
+				this.haveMissileTracker = true;
+			}
+		}
+
 	}
 
 	update(battleground: Battleground): void {


### PR DESCRIPTION
**Description**
Previously, tanks started with all of the one-time items, reguardless of which ones were equipped. This PR fixes that so that now they only start with the ones they actually have.

Here is a screenshot of the fixed healthbar:
![image](https://user-images.githubusercontent.com/18317476/79016837-ec8b6000-7b3d-11ea-9b6c-234cff9a1d9d.png)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/79016905-1cd2fe80-7b3e-11ea-86d0-77ca51b1a4f3.png)


**Resolves These Issues**
Resolves #403 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
Create a tank some subset of items. Exactly those items should show up in the healthbar and be usable.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)