### PR TITLE
Made name sizes scale down when they are too big

### DIFF
--- a/src/battleground/HealthBar.js
+++ b/src/battleground/HealthBar.js
@@ -60,7 +60,13 @@ class HealthBar extends React.Component<Props> {
 		// draw tank names
 		const oldFont=ctx.font;
 		const LIGHT_BLUE='#04CCFF';
+		const MAX_NAME_WIDTH=WIDTH*.19;
+		let fontSize=30;
 		ctx.font='normal small-caps 30px arial';
+		while (ctx.measureText(tank1?.tankName??'').width>MAX_NAME_WIDTH) {
+			fontSize--;
+			ctx.font='normal small-caps '+fontSize+'px arial';
+		}
 
 		let text=tank1?.tankName??'';
 		ctx.fillStyle='black';
@@ -69,6 +75,12 @@ class HealthBar extends React.Component<Props> {
 		ctx.fillStyle=LIGHT_BLUE;
 		ctx.fillText(text, WIDTH/80, HEIGHT*.4);
 
+		fontSize=30;
+		ctx.font='normal small-caps 30px arial';
+		while (ctx.measureText(tank2?.tankName??'').width>MAX_NAME_WIDTH) {
+			fontSize--;
+			ctx.font='normal small-caps '+fontSize+'px arial';
+		}
 		text=tank2?.tankName??'';
 		ctx.fillStyle='black';
 		width=ctx.measureText(text).width;


### PR DESCRIPTION
**Description**
In 1v1 battles, if a player's name is too big, it will be scaled down so it fits on the healthbar without looking silly. Here is an example:
![image](https://user-images.githubusercontent.com/18317476/79018785-a684cb00-7b42-11ea-8095-df2c7fbe5eb3.png)

Passes flow too:
![image](https://user-images.githubusercontent.com/18317476/79018826-c1573f80-7b42-11ea-8c87-76bcfc0082a5.png)


**Resolves These Issues**
Resolves #429 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)