### PR TITLE
Frontend 3v3 handling 1/2

### DIFF
--- a/src/armory/Armory.css
+++ b/src/armory/Armory.css
@@ -89,6 +89,18 @@
     background: none;
 }
 
+.removeTankBtn {
+    color: rgb(194, 0, 0);
+    border: none;
+    background: none;
+}
+
+.removeTankBtn:hover {
+    color: rgb(124, 0, 0);
+    border: none;
+    background: none;
+}
+
 .selectedTank {
     border: 0.2em solid #0062ff;
     color: #0062ff;

--- a/src/armory/Armory.css
+++ b/src/armory/Armory.css
@@ -98,7 +98,7 @@
 .removeTankBtn:hover {
     color: rgb(124, 0, 0);
     border: none;
-    background: none;
+    background:
 }
 
 .selectedTank {

--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -12,7 +12,7 @@ import DeleteTankPopup from './DeleteTankPopup.js';
 import SelectTank from '../globalComponents/SelectTank.js';
 import SetWagerPopup from './SetWagerPopup.js';
 import RenameTankPopup from './RenameTankPopup.js';
-import { ToastContainer } from 'react-toastify';
+import { ToastContainer, toast } from 'react-toastify';
 // Functions
 import { getComponentPoints, getComponentType } from '../globalComponents/GetInventoryInfo.js';
 import getUserAPICall from '../globalComponents/apiCalls/getUserAPICall.js';
@@ -130,7 +130,11 @@ class Armory extends React.Component<Props, State> {
 
 	// Find the tank via its id and set it to the selectedTank and its id in a Cookie for Casus.
 	// Also initializes the points for the new tank.
-	changeSelectedTank(newTank: Tank): void {
+	changeSelectedTank(newTank: ?Tank): void {
+		if (newTank == null) {
+			toast.error('New tank does not exist!');
+			return;
+		}
 		this.setState(
 			{selectedTank: newTank},
 			this.initPoints

--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -317,7 +317,7 @@ class Armory extends React.Component<Props, State> {
 				</div>
 				<div className="column armorymiddle">
 					<h1>{this.state.selectedTank.tankName}</h1>
-					<TankDisplay tankToDisplay={this.state.selectedTank} />
+					<TankDisplay tankToDisplay={this.state.selectedTank} smallTank={false} />
 					{(this.state.currentPartIndex === -1) ?
 						<div></div> :
 						<div>

--- a/src/backend/controllers/battleController.js
+++ b/src/backend/controllers/battleController.js
@@ -97,7 +97,7 @@ exports.prepareMatch1v1 = async (req: Request, res: Response) => {
 			eloExchanged: 0
 		});
 
-		if (Math.random()<0.5)) {
+		if (Math.random()<0.5) {
 			newRecord.map = 'DIRT';
 		} else {
 			newRecord.map = 'HEX';
@@ -223,7 +223,7 @@ exports.prepareMatch3v3 = async (req: Request, res: Response) => {
 			eloExchanged: 0
 		});
 		
-		if (Math.random()<0.5)) {
+		if (Math.random()<0.5) {
 			newRecord.map = 'CANDEN';
 		} else {
 			newRecord.map = 'LUNAR';

--- a/src/battlearena/BattleArena.css
+++ b/src/battlearena/BattleArena.css
@@ -43,7 +43,7 @@
 	height: 200px;
 	text-align: center;
 	overflow: hidden;
-	overflow-y: scroll;
+	overflow-y: auto;
 	list-style-type: none;
 }
 
@@ -67,6 +67,7 @@
 
 .replayTable tbody {
     height: 150px;
+    width: 100%;
     overflow-y: auto;
     overflow-x: auto;
 }

--- a/src/battlearena/BattleArena.css
+++ b/src/battlearena/BattleArena.css
@@ -89,3 +89,30 @@
     border-top: 1px solid #04CCFF;
     border-bottom: 1px solid #04CCFF;
 }
+
+/* Tank Display Styling */
+.threeTankDisplay {
+    text-align: center;
+}
+
+.threeTankDisplay thead, tbody {
+    display: inline-block;
+}
+
+.threeTankDisplay th {
+    width: 150px;
+}
+
+.threeTankDisplay td {
+    width: 33%;
+}
+
+.emptyTankSmall {
+    width: 150px;
+    height: 150px;
+}
+
+.emptyTankBig {
+    width: 300px;
+    height: 300px;
+}

--- a/src/battlearena/BattleArena.js
+++ b/src/battlearena/BattleArena.js
@@ -20,13 +20,17 @@ import getReplayListAPICall from '../globalComponents/apiCalls/getReplayListAPIC
 import { ToastContainer , toast } from 'react-toastify';
 import Replays from './Replays.js';
 import setBattlegroundArena from '../battleground/setBattlegroundArena.js';
+import type { BattleType } from '../globalComponents/typesAndClasses/BattleType.js';
 
 type Props = {||};
 
 type State = {|
-	selectedTank: ?Tank,
+	selectedTankOne: ?Tank,
+	selectedTankTwo: ?Tank,
+	selectedTankThree: ?Tank,
 	allTanks: Array<Tank>,
-	userElo: number
+	userElo: number,
+	battleType: BattleType
 |};
 
 class BattleArena extends React.Component<Props, State> {
@@ -35,9 +39,12 @@ class BattleArena extends React.Component<Props, State> {
 		super();
 		verifyLogin();
 		this.state = {
-			selectedTank: null,
+			selectedTankOne: null,
+			selectedTankTwo: null,
+			selectedTankThree: null,
 			allTanks: [],
 			userElo: 0,
+			battleType: '1 vs 1'
 		};
 	}
 
@@ -45,7 +52,7 @@ class BattleArena extends React.Component<Props, State> {
 		getAllUsersTanks(allTanks => {
 			this.setState({
 				allTanks: allTanks,
-				selectedTank: allTanks[0]
+				selectedTankOne: allTanks[0]
 			});
 		});
 		getReplayListAPICall(() => {});
@@ -58,7 +65,7 @@ class BattleArena extends React.Component<Props, State> {
 			toast.error('No player found.');
 			return;
 		}
-		const myTank = this.state.selectedTank;
+		const myTank = this.state.selectedTankOne;
 		if (myTank == null) {
 			toast.error('No selected tank for challenging.');
 			return;
@@ -92,16 +99,68 @@ class BattleArena extends React.Component<Props, State> {
 				<SearchPlayers onChallengePlayer={(user) => this.onChallengePlayer(user)} />
 			</div>
 			<div className="column bamiddle">
-				<h5>Choose your Tank, Commander</h5>
-				{
-					this.state.selectedTank==null?<div></div>:
-					<TankDisplay tankToDisplay={this.state.selectedTank} />
+				<h5>Choose your Tank{this.state.battleType === '1 vs 1' ? '' : 's'}, Commander</h5>
+				<br/>
+				{(this.state.battleType === '1 vs 1') ?
+					<div>
+						<SelectTank
+							selectedTank={this.state.selectedTankOne}
+							allTanks={this.state.allTanks}
+							changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
+						/>
+						{this.state.selectedTankOne == null ? <div className="emptyTankBig"></div> : <TankDisplay tankToDisplay={this.state.selectedTankOne} smallTank={false} />}
+					</div> :
+					<div className="threeTankDisplay">
+						<table>
+							<thead>
+								<tr>
+									<th>
+										<SelectTank
+											selectedTank={this.state.selectedTankTwo}
+											allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankThree)}
+											changeSelectedTank={(tank) => this.setState({selectedTankTwo: tank})}
+										/>
+									</th>
+									<th>
+										<SelectTank
+											selectedTank={this.state.selectedTankOne}
+											allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankThree && tank !== this.state.selectedTankTwo)}
+											changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
+										/>
+									</th>
+									<th>
+										<SelectTank
+											selectedTank={this.state.selectedTankThree}
+											allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankTwo)}
+											changeSelectedTank={(tank) => this.setState({selectedTankThree: tank})}
+										/>
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										{this.state.selectedTankTwo == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.selectedTankTwo} smallTank={true} />}
+										
+									</td>
+									<td>
+										{this.state.selectedTankOne == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.selectedTankOne} smallTank={true} />}
+									</td>
+									<td>
+										{this.state.selectedTankThree == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.selectedTankThree} smallTank={true} />}
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
 				}
-				<SelectTank
-					selectedTank={this.state.selectedTank}
-					allTanks={this.state.allTanks}
-					changeSelectedTank={(tank) => this.setState({selectedTank: tank})}
-				/>
+			<h5>Current Battle Type: {this.state.battleType}</h5>
+			<button 
+				className="primarybtn" 
+				onClick={(this.state.battleType === '1 vs 1') ? () => this.setState({battleType: '3 vs 3'}) : () => this.setState({battleType: '1 vs 1'})}
+			>
+				Change Battle Type
+			</button>
 			</div>
 			<div className="column baright">
 				<Leaderboard />

--- a/src/battlearena/BattleArena.js
+++ b/src/battlearena/BattleArena.js
@@ -68,15 +68,19 @@ class BattleArena extends React.Component<Props, State> {
 		}
 
 		// Ensure that the user has at least one set tank.
-		const myTankOne: Tank = this.state.selectedTankOne;
-		const myTankTwo: Tank = this.state.selectedTankTwo;
-		const myTankThree: Tank = this.state.selectedTankThree;
+		const myTankOne: ?Tank = this.state.selectedTankOne;
+		const myTankTwo: ?Tank = this.state.selectedTankTwo;
+		const myTankThree: ?Tank = this.state.selectedTankThree;
 		if (myTankOne == null && myTankTwo == null && myTankThree == null) {
-			toast.error('No selected tank for challenging.');
+			toast.error('No selected tank for challenging!');
 			return;
 		}
 
 		if (this.state.battleType === '1 vs 1') {
+			if (myTankOne == null) {
+				toast.error('No tank selected!');
+				return;
+			}
 			prepare1v1APICall(myTankOne, player, matchId => {
 				console.log('Successfully prepared match with id: '+matchId);
 				setMatchForBattleground(matchId);

--- a/src/battlearena/BattleArena.js
+++ b/src/battlearena/BattleArena.js
@@ -14,7 +14,7 @@ import Tank from '../tanks/Tank.js';
 import { getAllUsersTanks } from '../globalComponents/apiCalls/tankAPIIntegration.js';
 import TankDisplay from '../tanks/TankDisplay.js';
 import User from '../globalComponents/typesAndClasses/User.js';
-import prepareMatchAPICall from '../globalComponents/apiCalls/prepareMatchAPICall.js';
+import { prepare3v3APICall, prepare1v1APICall } from '../globalComponents/apiCalls/prepareMatchAPICall.js';
 import { setMatchForBattleground } from '../battleground/setTanksToFightInBattleground.js';
 import getReplayListAPICall from '../globalComponents/apiCalls/getReplayListAPICall.js';
 import { ToastContainer , toast } from 'react-toastify';
@@ -61,24 +61,39 @@ class BattleArena extends React.Component<Props, State> {
 	onChallengePlayer(player: ?User): void {
 		setReturnToFromBattlegroundLink('/BattleArena');
 
+		// Check if there is no player that is able to be challenged.
 		if (player == null) {
 			toast.error('No player found.');
 			return;
 		}
-		const myTank = this.state.selectedTankOne;
-		if (myTank == null) {
+
+		// Ensure that the user has at least one set tank.
+		const myTankOne: Tank = this.state.selectedTankOne;
+		const myTankTwo: Tank = this.state.selectedTankTwo;
+		const myTankThree: Tank = this.state.selectedTankThree;
+		if (myTankOne == null && myTankTwo == null && myTankThree == null) {
 			toast.error('No selected tank for challenging.');
 			return;
 		}
 
-		prepareMatchAPICall(myTank, player, matchId => {
-			console.log('Successfully prepared match with id: '+matchId);
-			setMatchForBattleground(matchId);
-			//TODO: select an appropriate arena depending on the match
-			setBattlegroundArena('DIRT');
-			window.location.href=verifyLink('/Battleground');
-		});
-
+		if (this.state.battleType === '1 vs 1') {
+			prepare1v1APICall(myTankOne, player, matchId => {
+				console.log('Successfully prepared match with id: '+matchId);
+				setMatchForBattleground(matchId);
+				//TODO: select an appropriate arena depending on the match
+				setBattlegroundArena('DIRT');
+				window.location.href=verifyLink('/Battleground');
+			});
+		}
+		else {
+			prepare3v3APICall(myTankOne, myTankTwo, myTankThree, player, matchId => {
+				console.log('Successfully prepared match with id: '+matchId);
+				setMatchForBattleground(matchId);
+				//TODO: select an appropriate arena depending on the match
+				setBattlegroundArena('DIRT');
+				window.location.href=verifyLink('/Battleground');
+			});
+		}
 	}
 
 

--- a/src/globalComponents/SelectTank.js
+++ b/src/globalComponents/SelectTank.js
@@ -53,9 +53,11 @@ class SelectTank extends React.Component<Props, State> {
 									<br/>
 								</div>
 							)}
-							<button className="removeTankBtn" onClick={() => this.onChangeSelectedTank(null)}>
-								Remove Tank
-							</button>
+							{window.location.pathname === '/Armory' ? <div></div> :
+								<button className="removeTankBtn" onClick={() => this.onChangeSelectedTank(null)}>
+									Remove Tank
+								</button>
+							}
 						</div> :
 						<div></div>
 					}

--- a/src/globalComponents/SelectTank.js
+++ b/src/globalComponents/SelectTank.js
@@ -22,7 +22,7 @@ class SelectTank extends React.Component<Props, State> {
 		};
 	}
 
-	onChangeSelectedTank(selectedTank: Tank): void {
+	onChangeSelectedTank(selectedTank: ?Tank): void {
 		this.props.changeSelectedTank(selectedTank);
 		this.setState({
 			showTanks: false

--- a/src/globalComponents/SelectTank.js
+++ b/src/globalComponents/SelectTank.js
@@ -5,7 +5,7 @@ import Tank from '../tanks/Tank.js';
 
 type Props = {|
 	allTanks: Array<Tank>,
-	changeSelectedTank: (Tank) => void,
+	changeSelectedTank: (?Tank) => void,
 	selectedTank: ?Tank,
 |};
 
@@ -36,7 +36,7 @@ class SelectTank extends React.Component<Props, State> {
 					className={(this.state.showTanks) ? "tankListBtn selectedTank" : "tankListBtn"}
 					onClick={() => this.setState({showTanks: true})}
 				>
-						{(this.props.selectedTank?.tankName??'Loading tanks...')} 
+						{(this.props.selectedTank?.tankName??'No Selected Tank')} 
 				</button>
 				<div>
 					{(this.state.showTanks) ?
@@ -53,6 +53,9 @@ class SelectTank extends React.Component<Props, State> {
 									<br/>
 								</div>
 							)}
+							<button className="removeTankBtn" onClick={() => this.onChangeSelectedTank(null)}>
+								Remove Tank
+							</button>
 						</div> :
 						<div></div>
 					}

--- a/src/globalComponents/apiCalls/prepareMatchAPICall.js
+++ b/src/globalComponents/apiCalls/prepareMatchAPICall.js
@@ -7,7 +7,7 @@ import { toast } from 'react-toastify';
 import getErrorFromObject from '../getErrorFromObject.js';
 
 //gets the user when passed a token stored as the login token
-function prepareMatchAPICall(myTank: Tank, otherPlayer: User, onLoad:(matchId: string) => void) {
+function prepare1v1APICall(myTank: Tank, otherPlayer: User, onLoad:(matchId: string) => void) {
 	const responsePromise: Promise<Response> = fetch('/api/battle/prepareMatch1v1', {
 		method: 'POST',
 		headers: {
@@ -37,5 +37,46 @@ function prepareMatchAPICall(myTank: Tank, otherPlayer: User, onLoad:(matchId: s
 	);
 }
 
+function prepare3v3APICall(myTankOne: ?Tank, myTankTwo: ?Tank, myTankThree: ?Tank, otherPlayer: User, onLoad:(matchId: string) => void) {
+	const myTankIds: Array<string> = [];
+	if (myTankOne != null) {
+		myTankIds.push(myTankOne._id);
+	}
+	if (myTankTwo != null) {
+		myTankIds.push(myTankTwo._id);
+	}
+	if (myTankThree != null) {
+		myTankIds.push(myTankThree._id);
+	}
 
-export default prepareMatchAPICall;
+	const responsePromise: Promise<Response> = fetch('api/battle/prepareMatch3v3', {
+		method: 'POST',
+		headers: {
+			'Access-Control-Allow-Origin': '*',
+			'Content-Type': 'application/json',
+			'Access-Control-Allow-Credentials': 'true',
+			'x-auth-token': getLoginToken()
+		},
+		body: JSON.stringify({
+			personBeingChallengedId: otherPlayer.userId,
+			challengerTankIds: myTankIds
+		})
+	});
+	responsePromise.then (
+		response => response.json().then(data => {
+			if (response.status !== 200) {
+				console.log(response.status);
+				console.log(data);
+				toast.error(getErrorFromObject(data));
+			}
+			else {
+				const matchId = data;
+				console.log('successfully created match with id: '+matchId);
+				onLoad(matchId);
+			}
+		})
+	);
+}
+
+
+export { prepare1v1APICall, prepare3v3APICall };

--- a/src/globalComponents/typesAndClasses/BattleType.js
+++ b/src/globalComponents/typesAndClasses/BattleType.js
@@ -1,0 +1,5 @@
+//@flow strict
+
+type BattleType = '1 vs 1' | '3 vs 3';
+
+export type { BattleType };

--- a/src/tanks/TankDisplay.css
+++ b/src/tanks/TankDisplay.css
@@ -1,4 +1,9 @@
 .tankDisplayCanvas {
-	width: 400px;
-	height: 400px;
+	width: 300px;
+	height: 300px;
+}
+
+.smallTankDisplayCanvas {
+	width: 150px;
+	height: 150px;
 }

--- a/src/tanks/TankDisplay.js
+++ b/src/tanks/TankDisplay.js
@@ -8,7 +8,8 @@ import { imageLoaderInit, addCallbackWhenImageLoaded } from '../battleground/Ima
 import './TankDisplay.css';
 
 type Props = {|
-	tankToDisplay: Tank
+	tankToDisplay: Tank,
+	smallTank: boolean
 |};
 
 const FPS=20;
@@ -54,7 +55,7 @@ class TankDisplay extends React.Component<Props> {
 		return (
 			<div>
 				<canvas
-					className="tankDisplayCanvas"
+					className={(this.props.smallTank) ? "smallTankDisplayCanvas" : "tankDisplayCanvas"}
 					ref="canvas"
 					width="400px"
 					height="400px"

--- a/src/trainingarena/TrainingArena.css
+++ b/src/trainingarena/TrainingArena.css
@@ -24,10 +24,6 @@
     width: 70%;
 }
 
-.tamiddle button {
-    margin-top: 10%;
-}
-
 .taright {
     width: 30%;
     margin-top: 10%;

--- a/src/trainingarena/TrainingArena.js
+++ b/src/trainingarena/TrainingArena.js
@@ -14,14 +14,21 @@ import TankDisplay from '../tanks/TankDisplay.js';
 import getBotTanksAPICall from '../globalComponents/apiCalls/getBotTanksAPICall.js';
 import setTanksToFightInBattleground from '../battleground/setTanksToFightInBattleground.js';
 import setBattlegroundArena from '../battleground/setBattlegroundArena.js';
+import { toast, ToastContainer } from 'react-toastify';
+import type { BattleType } from '../globalComponents/typesAndClasses/BattleType';
 
 type Props = {||};
 
 type State = {|
-	selectedTank: ?Tank,
+	selectedTankOne: ?Tank,
+	selectedTankTwo: ?Tank,
+	selectedTankThree: ?Tank,
 	allTanks: Array<Tank>,
-	enemySelectedTank: ?Tank,
-	enemyTanks: Array<Tank>,
+	botTankOne: ?Tank,
+	botTankTwo: ?Tank,
+	botTankThree: ?Tank,
+	botTanks: Array<Tank>,
+	battleType: BattleType
 |};
 
 class TrainingArena extends React.Component<Props, State> {
@@ -30,35 +37,56 @@ class TrainingArena extends React.Component<Props, State> {
 		super();
 		verifyLogin();
 		this.state = {
-			selectedTank: null,
+			selectedTankOne: null,
+			selectedTankTwo: null,
+			selectedTankThree: null,
 			allTanks: [],
-			enemySelectedTank: null,
-			enemyTanks: [],
+			botTankOne: null,
+			botTankTwo: null,
+			botTankThree: null,
+			botTanks: [],
+			battleType: '1 vs 1'
 		};
 	}
+
 	componentDidMount(): void {
 		getAllUsersTanks(allTanks => {
 				this.setState({
 					allTanks: allTanks,
-					selectedTank: allTanks[0]
+					selectedTankOne: allTanks[0]
 			});
 		});
-		getBotTanksAPICall(botTanks => this.setState({enemySelectedTank: botTanks[0], enemyTanks: botTanks}));
+		getBotTanksAPICall(botTanks => this.setState({botTankOne: botTanks[0], botTanks: botTanks}));
 	}
 
 	onClickStartBattle(): void {
-		const myTank=this.state.selectedTank;
-		const botTank=this.state.enemySelectedTank;
+		const myTankOne: Tank = this.state.selectedTankOne;
+		const myTankTwo: Tank = this.state.selectedTankTwo;
+		const myTankThree: Tank = this.state.selectedTankThree;
+		const botTankOne: Tank = this.state.botTankOne;
+		const botTankTwo: Tank = this.state.botTankTwo;
+		const botTankThree: Tank = this.state.botTankThree;
 		const arenaSelector: HTMLSelectElement=this.refs.arenaSelect;
-		if (myTank == null || botTank == null) {
-			throw new Error('neither tank should be null!');
+		if (myTankOne == null && myTankTwo == null && myTankThree == null) {
+			toast.error('One of your tanks must be selected!');
+			return;
+		}
+		if (botTankOne == null && botTankTwo == null && botTankThree == null) {
+			toast.error('One bot tank must be selected!');
+			return;
 		}
 		const selected = arenaSelector.value;
 		if (selected === 'DIRT' || selected === 'HEX' || selected === 'CANDEN' || selected === 'LUNAR') {
 			setBattlegroundArena(selected);
 		}
 		setReturnToFromBattlegroundLink('/TrainingArena');
-		setTanksToFightInBattleground(myTank._id, botTank._id);
+
+		if (this.state.battleType === '1 vs 1') {
+			setTanksToFightInBattleground(myTankOne._id, botTankOne._id);
+		}
+		else {
+
+		}
 
 		window.location.href=verifyLink('/Battleground');
 	}
@@ -119,6 +147,7 @@ class TrainingArena extends React.Component<Props, State> {
 						}}
 					/>
 				</div>
+				<ToastContainer />
 			</div>
 		)
 	}

--- a/src/trainingarena/TrainingArena.js
+++ b/src/trainingarena/TrainingArena.js
@@ -16,6 +16,7 @@ import setTanksToFightInBattleground from '../battleground/setTanksToFightInBatt
 import setBattlegroundArena from '../battleground/setBattlegroundArena.js';
 import { toast, ToastContainer } from 'react-toastify';
 import type { BattleType } from '../globalComponents/typesAndClasses/BattleType';
+import setTankForCasus from '../globalComponents/setTankForCasus.js';
 
 type Props = {||};
 
@@ -55,6 +56,7 @@ class TrainingArena extends React.Component<Props, State> {
 					allTanks: allTanks,
 					selectedTankOne: allTanks[0]
 			});
+			setTankForCasus(allTanks[0]._id);
 		});
 		getBotTanksAPICall(botTanks => this.setState({botTankOne: botTanks[0], botTanks: botTanks}));
 	}
@@ -81,6 +83,7 @@ class TrainingArena extends React.Component<Props, State> {
 		}
 		setReturnToFromBattlegroundLink('/TrainingArena');
 
+		// NEED TO UPDATE SET TANKS TO FIGHT IN BATTLEGROUND
 		if (this.state.battleType === '1 vs 1') {
 			setTanksToFightInBattleground(myTankOne._id, botTankOne._id);
 		}
@@ -101,19 +104,70 @@ class TrainingArena extends React.Component<Props, State> {
 				/>
 				<div className="column taleft">
 					<h5>Choose your Tank, Commander</h5>
-					{
-						this.state.selectedTank==null?<div></div>:
-						<TankDisplay tankToDisplay={this.state.selectedTank} />
+					<br/>
+					{(this.state.battleType === '1 vs 1') ?
+						<div>
+							<SelectTank
+								selectedTank={this.state.selectedTankOne}
+								allTanks={this.state.allTanks}
+								changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
+							/>
+							{this.state.selectedTankOne == null ? <div className="emptyTankBig"></div> : <TankDisplay tankToDisplay={this.state.selectedTankOne} smallTank={false} />}
+						</div> :
+						<div className="threeTankDisplay">
+							<table>
+								<thead>
+									<tr>
+										<th>
+											<SelectTank
+												selectedTank={this.state.selectedTankTwo}
+												allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankThree)}
+												changeSelectedTank={(tank) => this.setState({selectedTankTwo: tank})}
+											/>
+										</th>
+										<th>
+											<SelectTank
+												selectedTank={this.state.selectedTankOne}
+												allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankThree && tank !== this.state.selectedTankTwo)}
+												changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
+											/>
+										</th>
+										<th>
+											<SelectTank
+												selectedTank={this.state.selectedTankThree}
+												allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankTwo)}
+												changeSelectedTank={(tank) => this.setState({selectedTankThree: tank})}
+											/>
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>
+											{this.state.selectedTankTwo == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.selectedTankTwo} smallTank={true} />}
+											
+										</td>
+										<td>
+											{this.state.selectedTankOne == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.selectedTankOne} smallTank={true} />}
+										</td>
+										<td>
+											{this.state.selectedTankThree == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.selectedTankThree} smallTank={true} />}
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
 					}
-					<SelectTank
-						selectedTank={this.state.selectedTank}
-						allTanks={this.state.allTanks}
-						changeSelectedTank={(tank) => {
-							this.setState({selectedTank: tank});
-						}}
-					/>
 				</div>
 				<div className="column tamiddle">
+					<h5>Current Battle Type: {this.state.battleType}</h5>
+					<button 
+						className="primarybtn" 
+						onClick={(this.state.battleType === '1 vs 1') ? () => this.setState({battleType: '3 vs 3'}) : () => this.setState({battleType: '1 vs 1'})}
+					>
+						Change Battle Type
+					</button>
+					<br/><br/><br/>
 					<h5>Arena</h5>
 					<select className="dropdownMenu" ref="arenaSelect">
 						<option value="DIRT">Classic</option>
@@ -121,6 +175,7 @@ class TrainingArena extends React.Component<Props, State> {
 						<option value="CANDEN">Canden</option>
 						<option value="LUNAR">Lunar</option>
 					</select>
+					<br/><br/><br/>
 					<button 
 						type="button" 
 						className="primarybtn" 
@@ -128,24 +183,67 @@ class TrainingArena extends React.Component<Props, State> {
 					>
 						Start Battle
 					</button>
-					<br/>
+					<br/><br/>
 					<Link to={verifyLink("/Casus")}>
-						<button className="clearbtn">Back to Casus</button>
+						<button className="clearbtn">Click to go back to Casus</button>
 					</Link>
 				</div>
 				<div className="column taright">
 					<h5>Choose a Training Bot</h5>
-					{
-						this.state.enemySelectedTank==null?<div></div>:
-						<TankDisplay tankToDisplay={this.state.enemySelectedTank} />
+					<br/>
+					{(this.state.battleType === '1 vs 1') ?
+						<div>
+							<SelectTank
+								selectedTank={this.state.botTankOne}
+								allTanks={this.state.botTanks}
+								changeSelectedTank={(tank) => this.setState({botTankOne: tank})}
+							/>
+							{this.state.botTankOne == null ? <div className="emptyTankBig"></div> : <TankDisplay tankToDisplay={this.state.botTankOne} smallTank={false} />}
+						</div> :
+						<div className="threeTankDisplay">
+							<table>
+								<thead>
+									<tr>
+										<th>
+											<SelectTank
+												selectedTank={this.state.botTankTwo}
+												allTanks={this.state.botTanks}
+												changeSelectedTank={(tank) => this.setState({botTankTwo: tank})}
+											/>
+										</th>
+										<th>
+											<SelectTank
+												selectedTank={this.state.botTankOne}
+												allTanks={this.state.botTanks}
+												changeSelectedTank={(tank) => this.setState({botTankOne: tank})}
+											/>
+										</th>
+										<th>
+											<SelectTank
+												selectedTank={this.state.botTankThree}
+												allTanks={this.state.botTanks}
+												changeSelectedTank={(tank) => this.setState({botTankThree: tank})}
+											/>
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>
+											{this.state.botTankTwo == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.botTankTwo} smallTank={true} />}
+											
+										</td>
+										<td>
+											{this.state.botTankOne == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.botTankOne} smallTank={true} />}
+										</td>
+										<td>
+											{this.state.botTankThree == null ? <div className="emptyTankSmall"></div> : <TankDisplay tankToDisplay={this.state.botTankThree} smallTank={true} />}
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
 					}
-					<SelectTank
-						selectedTank={this.state.enemySelectedTank}
-						allTanks={this.state.enemyTanks}
-						changeSelectedTank={(tank) => {
-							this.setState({enemySelectedTank: tank});
-						}}
-					/>
 				</div>
 				<ToastContainer />
 			</div>

--- a/src/trainingarena/TrainingArena.js
+++ b/src/trainingarena/TrainingArena.js
@@ -62,12 +62,12 @@ class TrainingArena extends React.Component<Props, State> {
 	}
 
 	onClickStartBattle(): void {
-		const myTankOne: Tank = this.state.selectedTankOne;
-		const myTankTwo: Tank = this.state.selectedTankTwo;
-		const myTankThree: Tank = this.state.selectedTankThree;
-		const botTankOne: Tank = this.state.botTankOne;
-		const botTankTwo: Tank = this.state.botTankTwo;
-		const botTankThree: Tank = this.state.botTankThree;
+		const myTankOne: ?Tank = this.state.selectedTankOne;
+		const myTankTwo: ?Tank = this.state.selectedTankTwo;
+		const myTankThree: ?Tank = this.state.selectedTankThree;
+		const botTankOne: ?Tank = this.state.botTankOne;
+		const botTankTwo: ?Tank = this.state.botTankTwo;
+		const botTankThree: ?Tank = this.state.botTankThree;
 		const arenaSelector: HTMLSelectElement=this.refs.arenaSelect;
 		if (myTankOne == null && myTankTwo == null && myTankThree == null) {
 			toast.error('One of your tanks must be selected!');
@@ -81,10 +81,14 @@ class TrainingArena extends React.Component<Props, State> {
 		if (selected === 'DIRT' || selected === 'HEX' || selected === 'CANDEN' || selected === 'LUNAR') {
 			setBattlegroundArena(selected);
 		}
-		setReturnToFromBattlegroundLink('/TrainingArena');
 
-		// NEED TO UPDATE SET TANKS TO FIGHT IN BATTLEGROUND
+		// NEED TO UPDATE SET 3v3 TANKS TO FIGHT IN BATTLEGROUND
 		if (this.state.battleType === '1 vs 1') {
+			if (myTankOne == null || botTankOne == null) {
+				toast.error('One bot tank and one of your tanks must be selected!');
+				return;
+			}
+			setReturnToFromBattlegroundLink('/TrainingArena');
 			setTanksToFightInBattleground(myTankOne._id, botTankOne._id);
 		}
 		else {


### PR DESCRIPTION
**Description**
Sets up the look for frontend 3v3 battle handling. Needs more work to be finished. Currently, this creates the button to toggle 3v3 display and the 1v1 display in Battle Arena and Training Arena. I had to make edits for the SelectTank and TankDisplay components to get this to function correctly.

I have edited the prepareMatchAPICall to have one for 3v3 and one for 1v1 as well.

**Resolves These Issues**
Resolves none yet

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to battle arena.
2. Switch between 1v1 and 3v3.
3. Remove all selected tanks.
4. Try to challenge someone.
5. View toast error.
6. Go to 1v1 and ensure battles still work.
7. Go to training arena.
8. Switch between 1v1 and 3v3.
9. Remove all bot tanks and start battle.
10. View toast.
11. Remove all user tanks and start battle.
12. View different toast.
13. Go to 1v1 and ensure battles still work.
14. Go to armory to ensure the new TankDisplay and SelectTank haven't destroyed functionality.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)