### PR TITLE
Duplicate items cannot be equipped (except mines)

### DIFF
--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -162,6 +162,22 @@ class Armory extends React.Component<Props, State> {
 		});
 	}
 
+	// Checks the other items the tank has equipped in order to prevent two C4, nitro repair, etc.
+	checkItems(newComponent: TankComponent): boolean {
+		// Check if the new component is already in other slots, and that it is not a mine.
+		if (
+			((newComponent === this.state.selectedTank.parts[10].name) ||
+			(newComponent === this.state.selectedTank.parts[9].name) ||
+			(newComponent === this.state.selectedTank.parts[8].name)) &&
+			newComponent !== 'mine'
+		) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+
 	// Handles initializing points when the page is first loaded or when a new tank is selected.
 	initPoints(): void {
 		const tank: Tank = this.state.selectedTank;
@@ -174,6 +190,10 @@ class Armory extends React.Component<Props, State> {
 
 	// Ensure that the new point value doesn't go over the limit.
 	checkPoints(newComponent: TankComponent, oldPartIndex: number): boolean {
+		// Check the items to ensure that you don't have duplicate items (besides mine).
+		if (this.checkItems(newComponent)) {
+			return true;
+		}
 		return (this.state.points + getComponentPoints(newComponent) - getComponentPoints(this.state.selectedTank.parts[oldPartIndex].name) > 10) ? true : false;
 	}
 


### PR DESCRIPTION
**Description**
There is a checkItems function that runs inside the checkPoints function when deciding whether or not to disable a component that can be equipped.
![image](https://user-images.githubusercontent.com/42626045/79048967-bf4aba80-7bee-11ea-83fc-a7650a5d4181.png)


**Resolves These Issues**
Resolves #434 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to Armory.
2. Make sure you have all items and your tank has very few points.
3. Equip an item besides the mine.
4. Go to another item slot and see that the option for the previously equipped component is now disabled.
5. Equip two mines to ensure it isn't disabled.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)