### PR TITLE
Replay table now shows more information

### DIFF
--- a/src/battlearena/BattleArena.css
+++ b/src/battlearena/BattleArena.css
@@ -57,17 +57,14 @@
     text-align: center;
 }
 
-.replayTable table {
-    width: 100%;
-}
-
-.replayTable thead, tbody {
+.replayTable thead {
     display: block;
 }
 
 .replayTable tbody {
+    display: block;
     height: 150px;
-    width: 100%;
+    width: 450px;
     overflow-y: auto;
     overflow-x: auto;
 }
@@ -78,13 +75,13 @@
 
 .replayTable th {
     padding: 10px;
-    width: 20%;
     text-align: center;
+    width: 75px;
 }
 
 .replayTable td {
-    padding: 10px;
-    width: 20%;
+    width: 75px;
+    padding: 7px;
     border-left: none;
     border-right: none;
     border-top: 1px solid #04CCFF;

--- a/src/battlearena/BattleArena.css
+++ b/src/battlearena/BattleArena.css
@@ -52,7 +52,7 @@
 }
 
 /* Replay Table Styling */
-.replayList {
+.replayTable {
     font-size: 15px;
     text-align: center;
 }

--- a/src/battlearena/BattleArena.css
+++ b/src/battlearena/BattleArena.css
@@ -57,30 +57,36 @@
     text-align: center;
 }
 
+.replayTable table {
+    width: 80%;
+}
+
 .replayTable thead {
     display: block;
+    width: 100%;
 }
 
 .replayTable tbody {
+    width: 100%;
     display: block;
     height: 150px;
-    width: 450px;
     overflow-y: auto;
     overflow-x: auto;
 }
 
 .replayTable h4 {
-    text-align: center;
+    text-align: left;
+    margin-left: 10%;
 }
 
 .replayTable th {
     padding: 10px;
     text-align: center;
-    width: 75px;
+    width: 16%;
 }
 
 .replayTable td {
-    width: 75px;
+    width: 16%;
     padding: 7px;
     border-left: none;
     border-right: none;

--- a/src/battlearena/Replays.js
+++ b/src/battlearena/Replays.js
@@ -58,8 +58,9 @@ class Replays extends React.Component<Props, State> {
 	render(): React.Node {
 		return (
 			<div className="replayList">
-				<h4>{this.state.myUsername}'s Battle Record</h4>
+				
 				<div className="replayTable">
+					<h4>{this.state.myUsername}'s Battle Record</h4>
 					<table>
 						<thead>
 							<tr>

--- a/src/battlearena/Replays.js
+++ b/src/battlearena/Replays.js
@@ -58,7 +58,6 @@ class Replays extends React.Component<Props, State> {
 	render(): React.Node {
 		return (
 			<div className="replayList">
-				
 				<div className="replayTable">
 					<h4>{this.state.myUsername}'s Battle Record</h4>
 					<table>

--- a/src/battlearena/Replays.js
+++ b/src/battlearena/Replays.js
@@ -31,12 +31,12 @@ class Replays extends React.Component<Props, State> {
 		});
 	}
 
-	getWinner(replay: Replay): string {
+	getMatchResult(replay: Replay): string {
 		switch(replay.winner) {
 			case 2:
-				return replay.playerTwoName + ' won';
+				return (replay.playerTwoName === this.state.myUsername) ? 'Win' : 'Loss';
 			case 1:
-				return replay.playerOneName + ' won';
+				return (replay.playerOneName === this.state.myUsername) ? 'Win' : 'Loss';
 			case 0:
 				return 'tie';
 			case -1:
@@ -67,17 +67,19 @@ class Replays extends React.Component<Props, State> {
 								<th>Result</th>
 								<th>Replay</th>
 								<th>Prize</th>
-								<th>Elo Change</th>
+								<th>Elo</th>
+								<th>Type</th>
 							</tr>
 						</thead>
 						<tbody>
 							{this.state.replays.slice(0).reverse().map(replay => 
 								<tr key={replay.replayId}>
 									<td className="name">{(this.state.myUsername === replay.playerOneName) ? replay.playerTwoName : replay.playerOneName}</td>
-									<td>{this.getWinner(replay)}</td>
+									<td>{this.getMatchResult(replay)}</td>
 									<td><button className="reallySmallBtn" onClick={() => this.watchReplay(replay)}>View</button></td>
-									<td>{replay.prizeMoney}</td>
-									<td>{replay.eloExchanged}</td>
+									<td>{this.getMatchResult(replay) === 'Win' ? '+' + replay.prizeMoney : '-' + replay.prizeMoney}</td>
+									<td>{this.getMatchResult(replay) === 'Win' ? '+' + replay.eloExchanged : '-' + replay.eloExchanged}</td>
+									<td>{replay.tankOneName == null ? '3v3' : '1v1'}</td>
 								</tr>
 							)}
 						</tbody>

--- a/src/battlearena/Replays.js
+++ b/src/battlearena/Replays.js
@@ -57,34 +57,32 @@ class Replays extends React.Component<Props, State> {
 
 	render(): React.Node {
 		return (
-			<div className="replayList">
-				<div className="replayTable">
-					<h4>{this.state.myUsername}'s Battle Record</h4>
-					<table>
-						<thead>
-							<tr>
-								<th>Opponent</th>
-								<th>Result</th>
-								<th>Replay</th>
-								<th>Prize</th>
-								<th>Elo</th>
-								<th>Type</th>
+			<div className="replayTable">
+				<h4>{this.state.myUsername}'s Battle Record</h4>
+				<table>
+					<thead>
+						<tr>
+							<th>Opponent</th>
+							<th>Result</th>
+							<th>Replay</th>
+							<th>Prize</th>
+							<th>Elo</th>
+							<th>Type</th>
+						</tr>
+					</thead>
+					<tbody>
+						{this.state.replays.slice(0).reverse().map(replay => 
+							<tr key={replay.replayId}>
+								<td className="name">{(this.state.myUsername === replay.playerOneName) ? replay.playerTwoName : replay.playerOneName}</td>
+								<td>{this.getMatchResult(replay)}</td>
+								<td><button className="reallySmallBtn" onClick={() => this.watchReplay(replay)}>View</button></td>
+								<td>{this.getMatchResult(replay) === 'Win' ? '+' + replay.prizeMoney : '-' + replay.prizeMoney}</td>
+								<td>{this.getMatchResult(replay) === 'Win' ? '+' + replay.eloExchanged : '-' + replay.eloExchanged}</td>
+								<td>{replay.tankOneName == null ? '3v3' : '1v1'}</td>
 							</tr>
-						</thead>
-						<tbody>
-							{this.state.replays.slice(0).reverse().map(replay => 
-								<tr key={replay.replayId}>
-									<td className="name">{(this.state.myUsername === replay.playerOneName) ? replay.playerTwoName : replay.playerOneName}</td>
-									<td>{this.getMatchResult(replay)}</td>
-									<td><button className="reallySmallBtn" onClick={() => this.watchReplay(replay)}>View</button></td>
-									<td>{this.getMatchResult(replay) === 'Win' ? '+' + replay.prizeMoney : '-' + replay.prizeMoney}</td>
-									<td>{this.getMatchResult(replay) === 'Win' ? '+' + replay.eloExchanged : '-' + replay.eloExchanged}</td>
-									<td>{replay.tankOneName == null ? '3v3' : '1v1'}</td>
-								</tr>
-							)}
-						</tbody>
-					</table>
-				</div>
+						)}
+					</tbody>
+				</table>
 			</div>
 		);
 	}

--- a/src/globalComponents/apiCalls/getReplayListAPICall.js
+++ b/src/globalComponents/apiCalls/getReplayListAPICall.js
@@ -36,6 +36,9 @@ function getReplayListAPICall(onLoad:(replays: Array<Replay>) => void) {
 						backendReplay.prizeMoney,
 						backendReplay.eloExchanged,
 						backendReplay._id,
+						backendReplay.map,
+						backendReplay.tankTeamOne.map(tank => tank.tankName),
+						backendReplay.tankTeamTwo.map(tank => tank.tankName)
 					)
 				);
 				console.log('returned replays: ');

--- a/src/globalComponents/typesAndClasses/Map.js
+++ b/src/globalComponents/typesAndClasses/Map.js
@@ -1,5 +1,0 @@
-//@flow strict
-
-type Map = 'DIRT' | 'HEX' | 'LUNAR' | 'CANDEN';
-
-export type { Map };

--- a/src/globalComponents/typesAndClasses/Map.js
+++ b/src/globalComponents/typesAndClasses/Map.js
@@ -1,0 +1,5 @@
+//@flow strict
+
+type Map = 'DIRT' | 'HEX' | 'LUNAR' | 'CANDEN';
+
+export type { Map };

--- a/src/globalComponents/typesAndClasses/Replay.js
+++ b/src/globalComponents/typesAndClasses/Replay.js
@@ -1,4 +1,5 @@
 //@flow strict
+import type { Map } from './Map.js';
 
 class Replay {
 	tankOneName: string;
@@ -9,6 +10,9 @@ class Replay {
 	prizeMoney: number;
 	eloExchanged: number;
 	replayId: string;
+	map: Map;
+	tankTeamOneNames: Array<string>;
+	tankTeamTwoNames: Array<string>;
 
 	constructor(
 		tankOneName: string,
@@ -19,6 +23,9 @@ class Replay {
 		prizeMoney: number,
 		eloExchanged: number,
 		replayId: string,
+		map: Map,
+		tankTeamOneNames: Array<string>,
+		tankTeamTwoNames: Array<string>
 	) {
 		this.tankOneName=tankOneName;
 		this.tankTwoName=tankTwoName;
@@ -28,6 +35,9 @@ class Replay {
 		this.prizeMoney=prizeMoney;
 		this.eloExchanged=eloExchanged;
 		this.replayId=replayId;
+		this.map = map;
+		this.tankTeamOneNames = tankTeamOneNames;
+		this.tankTeamTwoNames = tankTeamTwoNames;
 	}
 }
 

--- a/src/globalComponents/typesAndClasses/Replay.js
+++ b/src/globalComponents/typesAndClasses/Replay.js
@@ -2,8 +2,8 @@
 import type { Map } from './Map.js';
 
 class Replay {
-	tankOneName: string;
-	tankTwoName: string;
+	tankOneName: ?string;
+	tankTwoName: ?string;
 	playerOneName: string;
 	playerTwoName: string;
 	winner: -1|0|1|2;
@@ -11,12 +11,12 @@ class Replay {
 	eloExchanged: number;
 	replayId: string;
 	map: Map;
-	tankTeamOneNames: Array<string>;
-	tankTeamTwoNames: Array<string>;
+	tankTeamOneNames: Array<?string>;
+	tankTeamTwoNames: Array<?string>;
 
 	constructor(
-		tankOneName: string,
-		tankTwoName: string,
+		tankOneName: ?string,
+		tankTwoName: ?string,
 		playerOneName: string,
 		playerTwoName: string,
 		winner: -1|0|1|2,
@@ -24,8 +24,8 @@ class Replay {
 		eloExchanged: number,
 		replayId: string,
 		map: Map,
-		tankTeamOneNames: Array<string>,
-		tankTeamTwoNames: Array<string>
+		tankTeamOneNames: Array<?string>,
+		tankTeamTwoNames: Array<?string>
 	) {
 		this.tankOneName=tankOneName;
 		this.tankTwoName=tankTwoName;

--- a/src/globalComponents/typesAndClasses/Replay.js
+++ b/src/globalComponents/typesAndClasses/Replay.js
@@ -1,5 +1,5 @@
 //@flow strict
-import type { Map } from './Map.js';
+import type { ArenaType } from '../../battleground/ArenaType.js';
 
 class Replay {
 	tankOneName: ?string;
@@ -10,7 +10,7 @@ class Replay {
 	prizeMoney: number;
 	eloExchanged: number;
 	replayId: string;
-	map: Map;
+	map: ArenaType;
 	tankTeamOneNames: Array<?string>;
 	tankTeamTwoNames: Array<?string>;
 
@@ -23,7 +23,7 @@ class Replay {
 		prizeMoney: number,
 		eloExchanged: number,
 		replayId: string,
-		map: Map,
+		map: ArenaType,
 		tankTeamOneNames: Array<?string>,
 		tankTeamTwoNames: Array<?string>
 	) {


### PR DESCRIPTION
**Description**
I updated the replay class to reflect the battle record model better for 3v3's. With this change, The replay table now can tell the difference between 1v1 and 3v3 battles.

Some additional changes, the prize money and elo exchanged now shows a + or - depending on if you won or lost. Also, the result no longer says "user won", instead it just says "Win" or "Loss".

![image](https://user-images.githubusercontent.com/42626045/79051264-44d56700-7bfd-11ea-9e14-d0d8e8c74d1f.png)


**Resolves These Issues**
Resolves #442 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Got to battle arena.
2. Make sure you have both a win and a loss.
3. View replay table updates and make sure they are concurrent with the changes from the battle (prize for victories shows + not -).

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)