### PR TITLE
Removed crash when switching from component to tank view

### DIFF
--- a/src/marketplace/ListingsView.js
+++ b/src/marketplace/ListingsView.js
@@ -92,7 +92,7 @@ class ListingsView extends React.Component<Props, State> {
 			if(this.props.sellerType === 'tanks') {
 				const tankId = this.state.itemsForSale[i].tankId;
 				if(tankId == null) {
-					throw new Error("Tank Id is null");
+					return (<h5>Loading Tanks...</h5>);
 				}
 				cards.push(
 						<div className="card mb-2" key={i}>


### PR DESCRIPTION
**Description**
When tanks from the marketplace are shown in ListingsView.js, they throw an error. I changed this so that instead of throwing an error, they simply render "Loading Tanks..." instead. This was a quick patch, let me know if there is more you want me to do with it.

**Resolves These Issues**
Resolves #474 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to marketplace.
2. View component listings (make sure there are actually components.
3. View tank listings. Shouldn't crash or say "Loading Tanks..." for a brief second.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)