### PR TITLE
Fixed a bug where casus variables weren't set for the first frame

### DIFF
--- a/src/casus/reviveCasusBlock.js
+++ b/src/casus/reviveCasusBlock.js
@@ -363,6 +363,7 @@ function reviveCasusBlock(orig: SomeBlockFromServer): CasusBlock {
 			return toReturn;
 		case 'MathPowBlock':
 			toReturn=new MathPowBlock();
+			toReturn.lChild=reviveCasusBlock(orig.lChild);
 			toReturn.rChild=reviveCasusBlock(orig.rChild);
 			return toReturn;
 		case 'MathSinBlock':

--- a/src/tanks/Tank.js
+++ b/src/tanks/Tank.js
@@ -186,6 +186,7 @@ class Tank extends GameObject {
 			battleground.deleteGameObject(this);
 			return;
 		}
+		this.setCasusVariables(battleground.getCollisionSegs(), battleground.getTanks(), battleground);
 		this.executeCasusFrame(battleground);	
 		this.executePhysics(battleground.getCollisionSegs(), battleground.getTanks(), battleground);
 	}
@@ -199,6 +200,39 @@ class Tank extends GameObject {
 		for (const debugLine of this.interpriterState.printedStatements) {
 			battleground.addDebugLine(' '+this.tankName+': '+debugLine);
 		}
+	}
+
+	setCasusVariables(walls: Array<Seg>, tanks: Array<Tank>, battleground: Battleground): void {
+		//set generic casus lists
+		const wallXs=[];
+		const wallYs=[];
+		for (const wall: Seg of walls) {
+			wallXs.push(wall.from.x);
+			wallYs.push(wall.from.y);
+			wallXs.push(wall.to.x);
+			wallYs.push(wall.to.y);
+		}
+		this._setDoubleArray(WALL_XS_VAR_NAME, wallXs);
+		this._setDoubleArray(WALL_YS_VAR_NAME, wallYs);
+
+		const enemyTanks=this._getEnemyTanks(battleground);
+		const otherTankXs=enemyTanks.map(tank => tank.getPosition().x);
+		const otherTankYs=enemyTanks.map(tank => tank.getPosition().y);
+		this._setDoubleArray(ENEMY_TANK_XS_VAR_NAME, otherTankXs);
+		this._setDoubleArray(ENEMY_TANK_YS_VAR_NAME, otherTankYs);
+
+		const friendlyTanks=this._getFriendlyTanks(battleground);
+		const friendlyTankXs=friendlyTanks.map(tank => tank.getPosition().x);
+		const friendlyTankYs=friendlyTanks.map(tank => tank.getPosition().y);
+		this._setDoubleArray(TEAM_TANK_XS_VAR_NAME, friendlyTankXs);
+		this._setDoubleArray(TEAM_TANK_YS_VAR_NAME, friendlyTankYs);
+
+		const mines=this._getMines(battleground);
+		const minesXs=mines.map(mine => mine.getPosition().x);
+		const minesYs=mines.map(mine => mine.getPosition().y);
+		this._setDoubleArray(EXPLOSIVE_XS_VAR_NAME, minesXs);
+		this._setDoubleArray(EXPLOSIVE_YS_VAR_NAME, minesYs);
+		//end of set generic casus lists
 	}
 	
 	executePhysics(walls: Array<Seg>, tanks: Array<Tank>, battleground: Battleground): void {
@@ -308,37 +342,6 @@ class Tank extends GameObject {
 			}
 		}
 		//end of updating tank parts
-		
-		//set generic casus lists
-		const wallXs=[];
-		const wallYs=[];
-		for (const wall: Seg of walls) {
-			wallXs.push(wall.from.x);
-			wallYs.push(wall.from.y);
-			wallXs.push(wall.to.x);
-			wallYs.push(wall.to.y);
-		}
-		this._setDoubleArray(WALL_XS_VAR_NAME, wallXs);
-		this._setDoubleArray(WALL_YS_VAR_NAME, wallYs);
-
-		const enemyTanks=this._getEnemyTanks(battleground);
-		const otherTankXs=enemyTanks.map(tank => tank.getPosition().x);
-		const otherTankYs=enemyTanks.map(tank => tank.getPosition().y);
-		this._setDoubleArray(ENEMY_TANK_XS_VAR_NAME, otherTankXs);
-		this._setDoubleArray(ENEMY_TANK_YS_VAR_NAME, otherTankYs);
-
-		const friendlyTanks=this._getFriendlyTanks(battleground);
-		const friendlyTankXs=friendlyTanks.map(tank => tank.getPosition().x);
-		const friendlyTankYs=friendlyTanks.map(tank => tank.getPosition().y);
-		this._setDoubleArray(TEAM_TANK_XS_VAR_NAME, friendlyTankXs);
-		this._setDoubleArray(TEAM_TANK_YS_VAR_NAME, friendlyTankYs);
-
-		const mines=this._getMines(battleground);
-		const minesXs=mines.map(mine => mine.getPosition().x);
-		const minesYs=mines.map(mine => mine.getPosition().y);
-		this._setDoubleArray(EXPLOSIVE_XS_VAR_NAME, minesXs);
-		this._setDoubleArray(EXPLOSIVE_YS_VAR_NAME, minesYs);
-		//end of set generic casus lists
 	}
 
 	intersectingTankOrWall(walls: Array<Seg>, tanks: Array<Tank>): boolean {


### PR DESCRIPTION
**Description**
Previously, casus variables weren't being set before the first frame, so any logic you did the first frame would be broken for that frame. This isn't a huge issue, but it would be for one-time items.

**Resolves These Issues**
Resolves I didn't make an issue for it

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)