### PR TITLE
Differently colored system variables in variable suggestion popup

### DIFF
--- a/src/Main.css
+++ b/src/Main.css
@@ -164,6 +164,32 @@ body {
 	border: 2px solid #04CCFF;
 }
 
+.popupbtnPink {
+	color: #04213F;
+	background: #ff00cb;
+	border: 2px solid #ff00cb;
+	border-radius: 3px;
+	margin-top: 20px;
+}
+.popupbtnPink:hover {
+	color: #ff00cb;
+	background: #500030;
+	border: 2px solid #ff00cb;
+}
+
+.popupbtnGray {
+	color: #04213F;
+	background: #aaaaaa;
+	border: 2px solid #aaaaaa;
+	border-radius: 3px;
+	margin-top: 20px;
+}
+.popupbtnGray:hover {
+	color: #aaaaaa;
+	background: #111122;
+	border: 2px solid #aaaaaa;
+}
+
 .closebtn {
 	color: #04213F;
 	background: #04CCFF;

--- a/src/casus/blocks/DefineFunctionBlock.js
+++ b/src/casus/blocks/DefineFunctionBlock.js
@@ -106,7 +106,7 @@ class DefineFunctionBlock extends CasusBlock {
 	}
 
 	getExistingVariableNames(dataType: DataType): Array<string> {
-		const existing=this.contents.getExistingVariableNames(dataType);
+		const existing=this.expanded?this.contents.getExistingVariableNames(dataType):[];
 		if (dataType === 'VOID' && !isDefaultVariableName(this.functionName)) {
 			if (!existing.includes(this.functionName)) {
 				existing.push(this.functionName);

--- a/src/casus/userInteraction/SelectVariablePopup.js
+++ b/src/casus/userInteraction/SelectVariablePopup.js
@@ -10,6 +10,7 @@ import {
 	FALSE_KEYWORD,
 	isLegalVariableName,
 	isLegalConstant,
+	isBuiltInVariable,
 } from '../userInteraction/defaultVariableNames.js';
 import type {DataType} from '../blocks/DataType.js';
 import {
@@ -59,6 +60,7 @@ class SelectVariablePopup extends React.Component<Props, State> {
 	render(): React.Node {
 		const enabled=this.getShouldBeAbleToClickCreateVariable();
 		const prepopulatedVariables=this.getPrepopulatedValues();
+		const dataType=this.getExpectedDataType();
 		const selectVariableOrFunctionText='Select '+this._functionOrVariableWord();
 
 		return (
@@ -71,14 +73,23 @@ class SelectVariablePopup extends React.Component<Props, State> {
 				<div className="popup centered">
 					<h2>{selectVariableOrFunctionText}</h2>
 
-					{prepopulatedVariables.map(name => (
-						<button
-							className="popupbtn normalPadding" 
+					{prepopulatedVariables.map(name => {
+						const constant=isLegalConstant(name, dataType);
+						const builtIn=isBuiltInVariable(name, dataType);
+						let className='popupbtnPink normalPadding';
+						if (constant) {
+							className='popupbtnGray normalPadding';
+						}
+						else if (builtIn) {
+							className='popupbtn normalPadding';
+						}
+						return (<button
+							className={className}
 							onClick= {() => this.onCreateVariableSelected(name)}
 							key={name}>
 							{name}
-						</button>
-					))}
+						</button>);
+					})}
 					<br/>
 					<input className="inputText" onChange={(e) => this.handleInputChange(e.target.value)}/>
 					<br/>


### PR DESCRIPTION
### **Description**
Color different types of blocks differently in the in the variable suggestion popup. Constants and system variables are grey and blue, custom variables are pink, matching Casus. Looks like this:
![image](https://user-images.githubusercontent.com/18317476/79287344-7ebe9b80-7e91-11ea-9711-fd0fd918e670.png)

Passes flow:
![image](https://user-images.githubusercontent.com/18317476/79287401-af063a00-7e91-11ea-88b3-41ae4163dcc2.png)


**Resolves These Issues**
Resolves #492 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
Make some custom variables and open the variable selection dialog

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)