### PR TITLE
Added atan2 block

### DIFF
--- a/src/casus/blockBank/BlockBankBlockShelf.js
+++ b/src/casus/blockBank/BlockBankBlockShelf.js
@@ -56,6 +56,7 @@ import MathTanBlock from '../blocks/MathTanBlock.js';
 import MathAcosBlock from '../blocks/MathAcosBlock.js';
 import MathAsinBlock from '../blocks/MathAsinBlock.js';
 import MathAtanBlock from '../blocks/MathAtanBlock.js';
+import MathAtan2Block from '../blocks/MathAtan2Block.js';
 import MathSqrtBlock from '../blocks/MathSqrtBlock.js';
 import MathPowBlock from '../blocks/MathPowBlock.js';
 
@@ -300,6 +301,7 @@ class BlockBankBlockShelf extends React.Component<Props, State> {
 		blocks.push(new MathAcosBlock());
 		blocks.push(new MathAsinBlock());
 		blocks.push(new MathAtanBlock());
+		blocks.push(new MathAtan2Block());
 		blocks.push(new MathSqrtBlock());
 		blocks.push(new MathPowBlock());
 		return blocks;

--- a/src/casus/blocks/BlockClass.js
+++ b/src/casus/blocks/BlockClass.js
@@ -45,6 +45,7 @@ type BlockClass =
 	'MathAcosBlock' |
 	'MathAsinBlock' |
 	'MathAtanBlock' |
+	'MathAtan2Block' |
 	'MathCosBlock' |
 	'MathPowBlock' |
 	'MathSinBlock' |

--- a/src/casus/blocks/MathAtan2Block.js
+++ b/src/casus/blocks/MathAtan2Block.js
@@ -1,0 +1,21 @@
+//@flow strict
+
+import BinaryOperationBlock from './BinaryOperationBlock.js';
+import DoubleValue from '../interpreter/DoubleValue.js';
+import {verifyDouble} from '../interpreter/Value.js';
+
+class MathAtan2Block extends BinaryOperationBlock {
+
+	constructor() {
+		super('MathAtan2Block', 'DOUBLE', 'DOUBLE', ', dx:', 'atan2 dy:');
+	}
+
+	evaluate(): DoubleValue {
+		const lRes=verifyDouble(this.lChild.runEvaluate());
+		const rRes=verifyDouble(this.rChild.runEvaluate());
+		return lRes.atan2(rRes);
+	}
+
+}
+
+export default MathAtan2Block;

--- a/src/casus/interpreter/DoubleValue.js
+++ b/src/casus/interpreter/DoubleValue.js
@@ -90,6 +90,10 @@ class DoubleValue {
 		return new DoubleValue(Math.tan(this.val));
 	}
 
+	atan2(o: DoubleValue): DoubleValue {
+		return new DoubleValue(Math.atan2(this.val, o.val));
+	}
+
 	pow(o: DoubleValue): DoubleValue {
 		if (this.val===0 && o.val === 0) {
 			return new DoubleValue(0);

--- a/src/casus/reviveCasusBlock.js
+++ b/src/casus/reviveCasusBlock.js
@@ -44,6 +44,7 @@ import ListSizeBlock from './blocks/ListSizeBlock.js';
 import MathAcosBlock from './blocks/MathAcosBlock.js';
 import MathAsinBlock from './blocks/MathAsinBlock.js';
 import MathAtanBlock from './blocks/MathAtanBlock.js';
+import MathAtan2Block from './blocks/MathAtan2Block.js';
 import MathCosBlock from './blocks/MathCosBlock.js';
 import MathSinBlock from './blocks/MathSinBlock.js';
 import MathSqrtBlock from './blocks/MathSqrtBlock.js';
@@ -355,6 +356,11 @@ function reviveCasusBlock(orig: SomeBlockFromServer): CasusBlock {
 			return toReturn;
 		case 'MathAtanBlock':
 			toReturn=new MathAtanBlock();
+			toReturn.rChild=reviveCasusBlock(orig.rChild);
+			return toReturn;
+		case 'MathAtan2Block':
+			toReturn=new MathAtan2Block();
+			toReturn.lChild=reviveCasusBlock(orig.lChild);
 			toReturn.rChild=reviveCasusBlock(orig.rChild);
 			return toReturn;
 		case 'MathCosBlock':


### PR DESCRIPTION
**Description**
Created an atan2 block. This makes aiming at the opponent one line:
![image](https://user-images.githubusercontent.com/18317476/79291003-7c613f00-7e9b-11ea-9e8c-a911c8ed0f00.png)


**Resolves These Issues**
Resolves #502

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
run that line on a tank with a scanner, and you should aim at the other tank

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)