### PR TITLE
Fixed username/password checking

### DIFF
--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -162,7 +162,7 @@ exports.login = async (req: Request, res: Response) => {
 		const user = await User.findOne({ userName: userName });
 
 		// Internal password constant
-		const passCheck = (user) ? user.password : "";
+		const passCheck = user?.password ?? '';
 
 		// Checks if the plaintext password matches the hashed pass form db
 		const isMatch = await bcrypt.compare(password, passCheck);

--- a/src/backend/controllers/userController.js
+++ b/src/backend/controllers/userController.js
@@ -161,8 +161,11 @@ exports.login = async (req: Request, res: Response) => {
 		// See if User exists - might change this to const
 		const user = await User.findOne({ userName: userName });
 
+		// Internal password constant
+		const passCheck = (user) ? user.password : "";
+
 		// Checks if the plaintext password matches the hashed pass form db
-		const isMatch = await bcrypt.compare(password, user.password);
+		const isMatch = await bcrypt.compare(password, passCheck);
 
 		// If the credentials don't match it will return a boolean false
 		if (!isMatch || user == null) {


### PR DESCRIPTION
**Description**
When we combined the logic to check for a valid username and password match, we forgot that the bcrypt check used `user.password` as an argument, so if the user const from the query was `null`, it broke the bcrypt call, causing the 500 server error status. This PR handles the `null` user query result in between the query and the bcrypt call.

**Resolves These Issues**
Resolves #501 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Attempt to login with your user, but:
  1a. Have the right password
  1b. Misspell your username.
2. Confirm the Server Error response doesn't come back, and the Incorrect Username or PW response comes instead,

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [x] This change requires a update in the design document (if applicable)