### PR TITLE
Updated the Listings to handle when the sellerId is Master's Id

### DIFF
--- a/src/marketplace/ListingsView.js
+++ b/src/marketplace/ListingsView.js
@@ -136,8 +136,9 @@ class ListingsView extends React.Component<Props, State> {
 			}
 			else {
 				cards.push(
-					<div className="card mb-2" key={i}>
+					<div className={this.state.itemsForSale[i].sellerId === '5e93b1d0d1125f22ecd469b7' ? "masterCard mb-2" : "card mb-2"} key={i}>
 						<div className="card-body">
+							{this.state.itemsForSale[i].sellerId === '5e93b1d0d1125f22ecd469b7' ? <h6>Master Listing: Unlimited Quantity</h6> : null}
 							<h5 className="card-title">{toTitleCase(this.state.itemsForSale[i].name)}</h5>
 							<h5 className="card-title">Price: ${this.state.itemsForSale[i].price}</h5>
 							<h5 className="card-title">Quantity: {this.state.itemsForSale[i].amount}</h5>

--- a/src/marketplace/Marketplace.css
+++ b/src/marketplace/Marketplace.css
@@ -18,3 +18,8 @@
 .card {
 	background-color: #3E5A6F;
 }
+
+.masterCard {
+	background-color: #04213F;
+	color: #04CCFF;
+}


### PR DESCRIPTION
**Description**
I added a new CSS that gives the listings cards a different background color when it is sold by master. Also, there is an extra header added.

![image](https://user-images.githubusercontent.com/42626045/79470435-60f75080-7fcf-11ea-8ebf-e1d862a86989.png)


**Resolves These Issues**
Resolves #488 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Open ListingsView.js
2. Change the Ids on line 139 and 141 to match the Id of someone selling on the marketplace.
3. Go to marketplace and view the listings that will have that Id.
4. View CSS changes.
5. Ensure Id I put in there matches the Master Account Id in the .env.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)