### PR TITLE
Added undo button in Casus that is in a fixed position

### DIFF
--- a/src/casus/CasusContainer.js
+++ b/src/casus/CasusContainer.js
@@ -48,6 +48,10 @@ class CasusContainer extends React.Component<Props, State> {
 					onBlocksDragged={this.onBlocksDragged} 
 					onDraggedBlocksReleased={this.onDraggedBlocksReleased}
 				/>
+				<div className="undoBtnArea">
+					<button className="undoBtn">Undo</button>
+					<button className="undoBtn" disabled={true}>Redo</button>
+				</div>
 				<CasusEditor 
 					draggedBlocks={this.state.draggedBlocks}
 					onBlocksDragged={this.onBlocksDragged} 

--- a/src/casus/CasusContainer.js
+++ b/src/casus/CasusContainer.js
@@ -48,10 +48,6 @@ class CasusContainer extends React.Component<Props, State> {
 					onBlocksDragged={this.onBlocksDragged} 
 					onDraggedBlocksReleased={this.onDraggedBlocksReleased}
 				/>
-				<div className="undoBtnArea">
-					<button className="undoBtn">Undo</button>
-					<button className="undoBtn" disabled={true}>Redo</button>
-				</div>
 				<CasusEditor 
 					draggedBlocks={this.state.draggedBlocks}
 					onBlocksDragged={this.onBlocksDragged} 

--- a/src/casus/CasusEditor.css
+++ b/src/casus/CasusEditor.css
@@ -26,6 +26,11 @@
 	background-color: gray;
 }
 
+.undoBtn:disabled:hover {
+	color: #04CCFF;
+	border: 1px solid #04CCFF;
+}
+
 .undoBtnArea {
 	text-align: right;
 	position: fixed;

--- a/src/casus/CasusEditor.css
+++ b/src/casus/CasusEditor.css
@@ -13,7 +13,10 @@
 	background-color: #000921;
 	color: #04CCFF;
 	border: 1px solid #04CCFF;
+	margin: 5px;
 	padding: 5px;
+	margin-top: 10px;
+	width: 70px;
 }
 
 .undoBtn:hover {

--- a/src/casus/CasusEditor.css
+++ b/src/casus/CasusEditor.css
@@ -8,3 +8,28 @@
 	height: 350px;
 	width: 100%;
 }
+
+.undoBtn {
+	background-color: #000921;
+	color: #04CCFF;
+	border: 1px solid #04CCFF;
+	padding: 5px;
+}
+
+.undoBtn:hover {
+	color: rgb(0, 114, 143);
+	border: 1px solid rgb(0, 114, 143);
+}
+
+.undoBtn:disabled {
+	cursor: default;
+	background-color: gray;
+}
+
+.undoBtnArea {
+	text-align: right;
+	position: fixed;
+	top: 100;
+	right: 0;
+	z-index: 100;
+}

--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -99,11 +99,6 @@ class CasusEditor extends React.Component<Props, State> {
 	onUndoRedoButtonClicked(undo: boolean): void {
 		const newCasusStateIndex=this.state.currentCasusState+(undo?-1:1);
 		const newState=casusBlockDeepCloneAsContainer(this.state.casusStates[newCasusStateIndex]);	
-		if (!undo) {
-			console.log('redo clicked');
-			console.log(newCasusStateIndex);
-			console.log(this.state.casusStates);
-		}
 		this.setState({
 			currentCasusState: newCasusStateIndex,
 			containerBlock: newState,
@@ -121,10 +116,6 @@ class CasusEditor extends React.Component<Props, State> {
 		if (JSON.stringify(toAdd) === JSON.stringify(oldState)) {
 			return;
 		}
-		else {
-			console.log(toAdd);
-			console.log(oldState);
-		}
 		let newStates=this.state.casusStates.slice(0, this.state.currentCasusState+1);
 		newStates.push(toAdd);
 		let curIndex=this.state.currentCasusState+1;
@@ -136,8 +127,6 @@ class CasusEditor extends React.Component<Props, State> {
 			currentCasusState: curIndex,
 			casusStates: newStates,
 		});
-		console.log('New index: '+curIndex);
-		console.log(newStates);
 	}
 
 	render(): React.Node {
@@ -206,7 +195,6 @@ class CasusEditor extends React.Component<Props, State> {
 	}
 
 	onMouseDown(e: MouseEvent) {
-		console.log(e);
 		const canvas: HTMLCanvasElement = this.refs.canvas;
 		const boundingBox: ClientRect = canvas.getBoundingClientRect();
 

--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -91,9 +91,6 @@ class CasusEditor extends React.Component<Props, State> {
 	render(): React.Node {
 		return (
 			<div className="casusEditorContainingDiv">
-				<div className="undoBtnArea">
-					<button className="undoBtn">Undo</button>
-				</div>
 				<canvas 
 					className="casusEditorCanvas"
 					ref="canvas" 

--- a/src/casus/CasusEditor.js
+++ b/src/casus/CasusEditor.js
@@ -91,6 +91,9 @@ class CasusEditor extends React.Component<Props, State> {
 	render(): React.Node {
 		return (
 			<div className="casusEditorContainingDiv">
+				<div className="undoBtnArea">
+					<button className="undoBtn">Undo</button>
+				</div>
 				<canvas 
 					className="casusEditorCanvas"
 					ref="canvas" 

--- a/src/casus/blockBank/BlockBank.css
+++ b/src/casus/blockBank/BlockBank.css
@@ -13,3 +13,7 @@
 	width: 100%;
 	height: 150px;
 }
+
+.stickyButton {
+	position: sticky;
+}

--- a/src/casus/casusBlockDeepClone.js
+++ b/src/casus/casusBlockDeepClone.js
@@ -2,6 +2,7 @@
 
 import CasusBlock from './blocks/CasusBlock.js';
 import reviveCasusBlock from './reviveCasusBlock.js';
+import {reviveAsContainer} from './reviveCasusBlock.js';
 
 // Creates a deep clone of this object.
 // This is helpful for copy-pasting purposes, for example
@@ -12,4 +13,12 @@ function casusBlockDeepClone(toClone: CasusBlock): CasusBlock {
 	return revived;
 }
 
+function casusBlockDeepCloneAsContainer(toClone: ContainerBlock): ContainerBlock {
+	const asJSON=JSON.stringify(toClone);
+	const withoutMethods=JSON.parse(asJSON);
+	const revived=reviveAsContainer(withoutMethods);
+	return revived;
+}
+
+export {casusBlockDeepCloneAsContainer};
 export default casusBlockDeepClone;

--- a/src/casus/casusBlockDeepClone.js
+++ b/src/casus/casusBlockDeepClone.js
@@ -3,6 +3,7 @@
 import CasusBlock from './blocks/CasusBlock.js';
 import reviveCasusBlock from './reviveCasusBlock.js';
 import {reviveAsContainer} from './reviveCasusBlock.js';
+import ContainerBlock from './blocks/ContainerBlock.js';
 
 // Creates a deep clone of this object.
 // This is helpful for copy-pasting purposes, for example


### PR DESCRIPTION
**Description**
The button is offset from the top to sit inside the area where users place their Casus code. It will be tied to the right hand side of the screen. There is also disabled CSS functionality if you need it disabled.

If you want me to move it or change its look, please let me know.

**At the top**
![image](https://user-images.githubusercontent.com/42626045/79472634-13301780-7fd2-11ea-9168-bfdd9de115b9.png)

**Scroll down to the bottom of the code**
![image](https://user-images.githubusercontent.com/42626045/79472701-293dd800-7fd2-11ea-8b18-8dc57cfdc76e.png)

**Resolves These Issues**
Resolves #509 

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to Casus.
2. View undo button.
3. Place a bunch of long code (if else statements work well).
4. Scroll down.
5. View the button is tied into the page even if scrolling.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)