### PR TITLE
Added variables for tank health, friendly tank health, and enemy tank health

### DIFF
--- a/src/battleground/Battleground.js
+++ b/src/battleground/Battleground.js
@@ -237,6 +237,7 @@ class Battleground extends React.Component<Props> {
 			//stop updating
 			return;
 		}
+		const loopStartTime=Date.now();
 		this.lifetimeCounter++;
 
 		//sort objects in render order
@@ -256,7 +257,9 @@ class Battleground extends React.Component<Props> {
 			this.gameObjects = this.gameObjects.filter(x => x !== toRemove);
 		}
 		this.objectsToDelete = [];
-		setTimeout(() => this._gameLoop(), 1000/FPS);
+		const loopEndTime=Date.now();
+		const nextFrameStartTime=loopStartTime+1000/FPS;
+		setTimeout(() => this._gameLoop(), Math.max(0, nextFrameStartTime-loopEndTime));
 	}
 
 	_update(): void {

--- a/src/casus/blocks/PrintBlock.js
+++ b/src/casus/blocks/PrintBlock.js
@@ -18,8 +18,11 @@ class PrintBlock extends UnaryOperationBlock {
 		if (res==null) {
 			throw new Error('Tried to print something that was null!');
 		}
-		if (res instanceof IntValue || res instanceof DoubleValue ) {
+		if (res instanceof IntValue) {
 			getInterpriterState().printDebugLine(res.val + '');
+		}
+		if (res instanceof DoubleValue) {
+			getInterpriterState().printDebugLine((Math.round(res.val * 1e3) / 1e3).toFixed(3));
 		}
 		if (res instanceof BooleanValue) {
 			getInterpriterState().printDebugLine(res.val ? 'true': 'false');

--- a/src/casus/userInteraction/CasusSpecialVariables.js
+++ b/src/casus/userInteraction/CasusSpecialVariables.js
@@ -21,12 +21,15 @@ const TARGET_DIRECTION_VAR_NAME: string = 'targetDirection';
 const TURRET_DIRECTION_VAR_NAME: string = 'turretDirection';
 const TANK_X_VAR_NAME: string = 'tankX';
 const TANK_Y_VAR_NAME: string = 'tankY';
+const TANK_HEALTH_VAR_NAME: string = 'tankHealth';
 
 //double lists
 const ENEMY_TANK_XS_VAR_NAME: string = 'enemyTankXs';
 const ENEMY_TANK_YS_VAR_NAME: string = 'enemyTankYs';
+const ENEMY_TANK_HEALTH_VAR_NAME: string = 'enemyTanksHealth';
 const TEAM_TANK_XS_VAR_NAME: string = 'friendlyTankXs';
 const TEAM_TANK_YS_VAR_NAME: string = 'friendlyTankYs';
+const TEAM_TANK_HEALTH_VAR_NAME: string = 'friendlyTanksHealth';
 const EXPLOSIVE_XS_VAR_NAME: string = 'explosiveXs';
 const EXPLOSIVE_YS_VAR_NAME: string = 'explosiveYs';
 const WALL_XS_VAR_NAME: string = 'wallXs';
@@ -53,13 +56,16 @@ const builtInDoubleVariables: Array<string> = [
 	TURRET_DIRECTION_VAR_NAME,
 	TANK_X_VAR_NAME,
 	TANK_Y_VAR_NAME,
+	TANK_HEALTH_VAR_NAME,
 ];
 
 const builtInDoubleListVariables: Array<string> = [
 	ENEMY_TANK_XS_VAR_NAME,
 	ENEMY_TANK_YS_VAR_NAME,
+	ENEMY_TANK_HEALTH_VAR_NAME,
 	TEAM_TANK_XS_VAR_NAME,
 	TEAM_TANK_YS_VAR_NAME,
+	TEAM_TANK_HEALTH_VAR_NAME,
 	EXPLOSIVE_XS_VAR_NAME,
 	EXPLOSIVE_YS_VAR_NAME,
 	WALL_XS_VAR_NAME,
@@ -82,11 +88,14 @@ export {
 	TURRET_DIRECTION_VAR_NAME,
 	TANK_X_VAR_NAME,
 	TANK_Y_VAR_NAME,
+	TANK_HEALTH_VAR_NAME,
 
 	ENEMY_TANK_XS_VAR_NAME,
 	ENEMY_TANK_YS_VAR_NAME,
+	ENEMY_TANK_HEALTH_VAR_NAME,
 	TEAM_TANK_XS_VAR_NAME,
 	TEAM_TANK_YS_VAR_NAME,
+	TEAM_TANK_HEALTH_VAR_NAME,
 	EXPLOSIVE_XS_VAR_NAME,
 	EXPLOSIVE_YS_VAR_NAME,
 	WALL_XS_VAR_NAME,

--- a/src/tanks/Tank.js
+++ b/src/tanks/Tank.js
@@ -42,11 +42,14 @@ import {
 	TARGET_DIRECTION_VAR_NAME,
 	TANK_X_VAR_NAME,
 	TANK_Y_VAR_NAME,
+	TANK_HEALTH_VAR_NAME,
 
 	ENEMY_TANK_XS_VAR_NAME,
 	ENEMY_TANK_YS_VAR_NAME,
+	ENEMY_TANK_HEALTH_VAR_NAME,
 	TEAM_TANK_XS_VAR_NAME,
 	TEAM_TANK_YS_VAR_NAME,
+	TEAM_TANK_HEALTH_VAR_NAME,
 	EXPLOSIVE_XS_VAR_NAME,
 	EXPLOSIVE_YS_VAR_NAME,
 	WALL_XS_VAR_NAME,
@@ -203,6 +206,10 @@ class Tank extends GameObject {
 	}
 
 	setCasusVariables(walls: Array<Seg>, tanks: Array<Tank>, battleground: Battleground): void {
+		this._setDouble(TANK_X_VAR_NAME, this.position.x);
+		this._setDouble(TANK_Y_VAR_NAME, this.position.y);
+		this._setDouble(TANK_HEALTH_VAR_NAME, this.health);
+
 		//set generic casus lists
 		const wallXs=[];
 		const wallYs=[];
@@ -218,14 +225,18 @@ class Tank extends GameObject {
 		const enemyTanks=this._getEnemyTanks(battleground);
 		const otherTankXs=enemyTanks.map(tank => tank.getPosition().x);
 		const otherTankYs=enemyTanks.map(tank => tank.getPosition().y);
+		const otherTankHealths=enemyTanks.map(tank => tank.health);
 		this._setDoubleArray(ENEMY_TANK_XS_VAR_NAME, otherTankXs);
 		this._setDoubleArray(ENEMY_TANK_YS_VAR_NAME, otherTankYs);
+		this._setDoubleArray(ENEMY_TANK_HEALTH_VAR_NAME, otherTankHealths);
 
 		const friendlyTanks=this._getFriendlyTanks(battleground);
 		const friendlyTankXs=friendlyTanks.map(tank => tank.getPosition().x);
 		const friendlyTankYs=friendlyTanks.map(tank => tank.getPosition().y);
+		const friendlyTankHealths=friendlyTanks.map(tank => tank.health);
 		this._setDoubleArray(TEAM_TANK_XS_VAR_NAME, friendlyTankXs);
 		this._setDoubleArray(TEAM_TANK_YS_VAR_NAME, friendlyTankYs);
+		this._setDoubleArray(TEAM_TANK_HEALTH_VAR_NAME, friendlyTankHealths);
 
 		const mines=this._getMines(battleground);
 		const minesXs=mines.map(mine => mine.getPosition().x);
@@ -273,8 +284,6 @@ class Tank extends GameObject {
 		}
 
 		this._setBoolean(RAN_INTO_WALL_VAR_NAME, ranIntoWall);
-		this._setDouble(TANK_X_VAR_NAME, this.position.x);
-		this._setDouble(TANK_Y_VAR_NAME, this.position.y);
 		//end of movement stuff
 		
 		//gun stuff


### PR DESCRIPTION
**Description**
Added casus variables and functionality for being able to get your own tank health, the enemy's tank health, and your ally's tank health.

**Resolves These Issues**
Resolves #511

**Type of change**
Check options that are relevant.

- [ ] Bug fix (fixes a bug issue)
- [x] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
Make a bulleted/numbered list of steps to verify this feature/bugfix. Include screenshots if necessary.
- Make a new tank with a scanner
- Write casus code to display your own tank's health
- Write casus code that makes your own tank display the health of the first enemy it sees.
- You should see reasonable values being printed in the casus list of printed statements

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)