### PR TITLE
Removed infinite get users calls in Battle Arena

### DIFF
--- a/src/battlearena/SearchPlayers.js
+++ b/src/battlearena/SearchPlayers.js
@@ -50,11 +50,11 @@ class SearchPlayers extends React.Component<Props, State> {
 		});
 	}
 
-	componentDidUpdate(): void {
+	componentWillReceiveProps(newProps: Props): void {
 		// Update the search players when the battleType changes.
 		const myUsername=new Cookie().get('username');
 		getAllUsersAPICall(allUsers => {
-			if (this.props.battleType === '1 vs 1') {
+			if (newProps.battleType === '1 vs 1') {
 				this.setState({playerList: allUsers.filter(user => user.username !== myUsername && user.wager > 0)});
 			}
 			else {

--- a/src/battlearena/SearchPlayers.js
+++ b/src/battlearena/SearchPlayers.js
@@ -14,7 +14,8 @@ type Props = {|
 
 type State = {|
 	queryString: string,
-	playerList: Array<User>,
+	player1v1List: Array<User>,
+	player3v3List: Array<User>
 |};
 
 // Search Players Component. Takes an array of all players.
@@ -33,7 +34,8 @@ class SearchPlayers extends React.Component<Props, State> {
 
 		this.state = {
 			queryString: '',
-			playerList: [],
+			player1v1List: [],
+			player3v3List: []
 		}
 	}
 
@@ -41,25 +43,10 @@ class SearchPlayers extends React.Component<Props, State> {
 		//set by navbar
 		const myUsername=new Cookie().get('username');
 		getAllUsersAPICall(allUsers => {
-			if (this.props.battleType === '1 vs 1') {
-				this.setState({playerList: allUsers.filter(user => user.username !== myUsername && user.wager > 0)});
-			}
-			else {
-				this.setState({playerList: allUsers.filter(user => user.username !== myUsername && user.wager3v3 > 0)});
-			}
-		});
-	}
-
-	componentWillReceiveProps(newProps: Props): void {
-		// Update the search players when the battleType changes.
-		const myUsername=new Cookie().get('username');
-		getAllUsersAPICall(allUsers => {
-			if (newProps.battleType === '1 vs 1') {
-				this.setState({playerList: allUsers.filter(user => user.username !== myUsername && user.wager > 0)});
-			}
-			else {
-				this.setState({playerList: allUsers.filter(user => user.username !== myUsername && user.wager3v3 > 0)});
-			}
+			this.setState({
+				player1v1List: allUsers.filter(user => user.username !== myUsername && user.wager > 0),
+				player3v3List: allUsers.filter(user => user.username !== myUsername && user.wager3v3 > 0)
+			});
 		});
 	}
 
@@ -68,8 +55,9 @@ class SearchPlayers extends React.Component<Props, State> {
 	}
 
 	render(): React.Node {
-		const playersToRender = this.state.playerList.filter(
-			user => user.username.includes(this.state.queryString)
+		const playersToRender = (this.props.battleType === '1 vs 1' ? 
+			this.state.player1v1List.filter(user => user.username.includes(this.state.queryString)) :
+			this.state.player3v3List.filter(user => user.username.includes(this.state.queryString))
 		);
 		return (
 			<div className="searchPlayers">


### PR DESCRIPTION
**Description**
I made two separate lists that the frontend will switch between when changing battle type.

**Resolves These Issues**
Resolves #512 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to Battle Arena.
2. Check DB to make sure it doesn't load all users infinitely. 
3. Make sure you have a separate 3v3 and 1v1 wager setup.
4. Switch between battle types in the Battle Arena to make sure the wagers appear correctly.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)