### PR TITLE
3v3 Wagers now set correctly

### DIFF
--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -151,7 +151,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 			});
 
 			// Create an array of tank ids to be sent to the backend.
-			const favoriteTankTeamIds: Array<string> = [];
+			const favoriteTankTeamIds: Array<?string> = [];
 			for(let i: number = 0; i < 3; i++) {
 				favoriteTankTeamIds.push(this.state.newWager3v3Tanks[i] == null ? null : this.state.newWager3v3Tanks[i]._id);
 			}

--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -112,11 +112,18 @@ class SetWagerPopup extends React.Component<Props, State> {
 
 	// Set the user's wager and favorite tank.
 	handleWagerClick(): void {
+		// Error handling.
+		if (this.state.newWager < 50) {
+			toast.error('Wager cannot be less than 50!');
+			return;
+		}
+
 		// Set the new wager and favorite tank depending on the battleType.
 		if (this.state.battleType === '1 vs 1') {
 			setWager(this.state.newWager, stipendApplied => {
 				if (this.state.newWager1v1Tank._id === '') {
 					toast.error('Tank not loaded yet, select it again.');
+					return;
 				}
 				if (stipendApplied) {
 					toast.success('$100 added for setting your daily wager!');
@@ -142,7 +149,13 @@ class SetWagerPopup extends React.Component<Props, State> {
 				// Update user currency in the navbar.
 				this.props.onWagerUpdate();
 			});
-			setFavoriteTankTeamIds(this.state.newWager3v3Tanks.map(tank => tank == null ? null : tank._id), () => {
+
+			// Create an array of tank ids to be sent to the backend.
+			const favoriteTankTeamIds: Array<string> = [];
+			for(let i: number = 0; i < 3; i++) {
+				favoriteTankTeamIds.push(this.state.newWager3v3Tanks[i] == null ? null : this.state.newWager3v3Tanks[i]._id);
+			}
+			setFavoriteTankTeamIds(favoriteTankTeamIds, () => {
 				this.setState({setWagerOpen: false, userWager3v3Tanks: this.state.newWager3v3Tanks});
 			});
 		}
@@ -166,8 +179,8 @@ class SetWagerPopup extends React.Component<Props, State> {
 	}
 
 	// Updates newWager3v3Tanks when changing a tank.
-	update3v3Tanks(newTankName: string, tankIndex: number): void {
-		const newTank: Tank = this.state.allTanks[this.state.allTanks.findIndex(tank => tank.tankName === newTankName)];
+	update3v3Tanks(newTankId: string, tankIndex: number): void {
+		const newTank: Tank = this.state.allTanks[this.state.allTanks.findIndex(tank => tank._id === newTankId)];
 		let newWager3v3Tanks: Array<?Tank> = this.state.newWager3v3Tanks;
 		newWager3v3Tanks[tankIndex] = newTank;
 		this.setState({newWager3v3Tanks: newWager3v3Tanks});
@@ -267,11 +280,11 @@ class SetWagerPopup extends React.Component<Props, State> {
 								<div>
 									<select 
 										className="dropdownMenu"
-										onChange={(e) => this.setState({newWager1v1Tank: this.state.allTanks[this.state.allTanks.findIndex(tank => tank.tankName === e.target.value)]})}
+										onChange={(e) => this.setState({newWager1v1Tank: this.state.allTanks[this.state.allTanks.findIndex(tank => tank._id === e.target.value)]})}
 									>
-										{this.state.allTanks.map(tank => tank.tankName).map((tankName, index) => 
-											<option key={index}>
-												{tankName}
+										{this.state.allTanks.map((tank, index) => 
+											<option key={index} value={tank._id}>
+												{tank.tankName}
 											</option>
 										)}
 									</select>
@@ -284,10 +297,9 @@ class SetWagerPopup extends React.Component<Props, State> {
 										<option value={null}>No Tank</option>
 										{this.state.allTanks
 											.filter(tank => tank !== this.state.newWager3v3Tanks[1] && tank !== this.state.newWager3v3Tanks[2])
-											.map(tank => tank.tankName)
-											.map((tankName, index) => 
-												<option key={index}>
-													{tankName}
+											.map((tank, index) => 
+												<option key={index} value={tank._id}>
+													{tank.tankName}
 												</option>
 											)
 										}
@@ -300,10 +312,9 @@ class SetWagerPopup extends React.Component<Props, State> {
 										<option value={null}>No Tank</option>
 										{this.state.allTanks
 											.filter(tank => tank !== this.state.newWager3v3Tanks[0] && tank !== this.state.newWager3v3Tanks[2])
-											.map(tank => tank.tankName)
-											.map((tankName, index) => 
-												<option key={index}>
-													{tankName}
+											.map((tank, index) => 
+												<option key={index} value={tank._id}>
+													{tank.tankName}
 												</option>
 											)
 										}
@@ -316,10 +327,9 @@ class SetWagerPopup extends React.Component<Props, State> {
 										<option value={null}>No Tank</option>
 										{this.state.allTanks
 											.filter(tank => tank !== this.state.newWager3v3Tanks[0] && tank !== this.state.newWager3v3Tanks[1])
-											.map(tank => tank.tankName)
-											.map((tankName, index) => 
-												<option key={index}>
-													{tankName}
+											.map((tank, index) => 
+												<option key={index} value={tank._id}>
+													{tank.tankName}
 												</option>
 											)
 										}

--- a/src/backend/controllers/tankController.js
+++ b/src/backend/controllers/tankController.js
@@ -229,7 +229,7 @@ exports.unfavoriteTankTeam = async (req: Request, res: Response) => {
 	}
 
 	// Find the user and set favoriteTank to null.
-	const user = await User.findById(req.user.id, 'wager money favoriteTanks');
+	const user = await User.findById(req.user.id, 'wager3v3 money favoriteTanks');
 
 	// Check if found.
 	if (user == null) {
@@ -239,7 +239,7 @@ exports.unfavoriteTankTeam = async (req: Request, res: Response) => {
 			.json({ msg: 'Could not find user in db'});
 	}
 
-	const addBack = user.money + user.wager;
+	const addBack = user.money + user.wager3v3;
 	user.money = addBack;
 	user.favoriteTanks = [null, null, null];
 	user.wager3v3 = 0;

--- a/src/globalComponents/apiCalls/tankAPIIntegration.js
+++ b/src/globalComponents/apiCalls/tankAPIIntegration.js
@@ -92,6 +92,7 @@ function getFavoriteTankTeam(onLoad:(tanks: Array<?Tank>) => void): void {
 	)
 }
 
+// Set the user's favorite tank via ID.
 function setFavoriteTankId(tankId: string, onLoad:() => void): void {
 	const responsePromise: Promise<Response> = fetch('/api/tank/favoriteTank/', {
 		method: 'PATCH',
@@ -117,6 +118,7 @@ function setFavoriteTankId(tankId: string, onLoad:() => void): void {
 	);
 }
 
+// Set the user's favorite tank team via ID.
 function setFavoriteTankTeamIds(tankIds: Array<?string>, onLoad:() => void): void {
 	const responsePromise: Promise<Response> = fetch('/api/tank/setFavoriteTankTeam/', {
 		method: 'PATCH',
@@ -133,7 +135,7 @@ function setFavoriteTankTeamIds(tankIds: Array<?string>, onLoad:() => void): voi
 			if (response.status !== 200) {
 				console.log(response.status);
 				console.log(data);
-				toast.error(data);
+				toast.error(getErrorFromObject(data));
 			}
 			else {
 				onLoad();

--- a/src/globalComponents/apiCalls/tankAPIIntegration.js
+++ b/src/globalComponents/apiCalls/tankAPIIntegration.js
@@ -109,7 +109,7 @@ function setFavoriteTankId(tankId: string, onLoad:() => void): void {
 			if (response.status !== 200) {
 				console.log(response.status);
 				console.log(data);
-				toast.error(getErrorFromObject(data));
+				toast.error(data);
 			}
 			else {
 				onLoad();
@@ -135,7 +135,7 @@ function setFavoriteTankTeamIds(tankIds: Array<?string>, onLoad:() => void): voi
 			if (response.status !== 200) {
 				console.log(response.status);
 				console.log(data);
-				toast.error(getErrorFromObject(data));
+				toast.error(data);
 			}
 			else {
 				onLoad();

--- a/src/globalComponents/apiCalls/tankAPIIntegration.js
+++ b/src/globalComponents/apiCalls/tankAPIIntegration.js
@@ -109,7 +109,7 @@ function setFavoriteTankId(tankId: string, onLoad:() => void): void {
 			if (response.status !== 200) {
 				console.log(response.status);
 				console.log(data);
-				toast.error(data);
+				toast.error(getErrorFromObject(data));
 			}
 			else {
 				onLoad();


### PR DESCRIPTION
**Description**
3v3 Wagers now have the correct tank id array passed to them. Previously it was not passing an array that was always length 3.

**Resolves These Issues**
Resolves #527 

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to armory.
2. Set 3v3 wager.
3. Remove 3v3 wager.
4. Make sure you db is updating correctly with the money and favorite tank team.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)