### PR TITLE
Wagers now uses SelectTank.js

### DIFF
--- a/src/armory/Armory.js
+++ b/src/armory/Armory.js
@@ -322,6 +322,7 @@ class Armory extends React.Component<Props, State> {
 							allTanks={this.state.allTanks}
 							changeSelectedTank={(tank) => this.changeSelectedTank(tank)}
 							propogateChangesToCasus={true}
+							allowRemoveTank={false}
 						/>
 					}
 					<br/><br/>

--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -16,8 +16,7 @@ import {
 } from '../globalComponents/apiCalls/tankAPIIntegration.js';
 import { ToastContainer , toast } from 'react-toastify';
 import type { BattleType } from '../globalComponents/typesAndClasses/BattleType.js';
-import { getEmptyCasusCode, getTank } from '../tanks/TankLoader.js';
-import BackendTank from '../tanks/BackendTank.js';
+import SelectTank from '../globalComponents/SelectTank.js';
 
 type Props = {|
 	onWagerUpdate: () => void
@@ -32,7 +31,7 @@ type State = {|
 	userWager3v3Tanks: Array<?Tank>,
 	userWager1v1Tank: ?Tank,
 	newWager3v3Tanks: Array<?Tank>,
-	newWager1v1Tank: Tank,
+	newWager1v1Tank: ?Tank,
 	setWagerOpen: boolean,
 	removeWagerOpen: boolean,
 	battleType: BattleType
@@ -41,16 +40,6 @@ type State = {|
 class SetWagerPopup extends React.Component<Props, State> {
 	constructor(props: Props) {
 		super(props);
-
-		// Create a blank tank as a placeholder until tanks are pulled.
-		const blankTank: BackendTank = new BackendTank(
-			'',
-			['empty', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty', 'empty',],
-			getEmptyCasusCode(),
-			false,
-			'',
-			''
-		);
 
 		this.state = {
 			allTanks: [],
@@ -61,7 +50,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 			userWager3v3Tanks: [null, null, null],
 			userWager1v1Tank: null,
 			newWager3v3Tanks: [],
-			newWager1v1Tank: getTank(blankTank),
+			newWager1v1Tank: null,
 			setWagerOpen: false,
 			removeWagerOpen: false,
 			battleType: '1 vs 1'
@@ -120,11 +109,11 @@ class SetWagerPopup extends React.Component<Props, State> {
 
 		// Set the new wager and favorite tank depending on the battleType.
 		if (this.state.battleType === '1 vs 1') {
+			if (this.state.newWager1v1Tank == null) {
+				toast.error('No set wager tank!');
+				return;
+			}
 			setWager(this.state.newWager, stipendApplied => {
-				if (this.state.newWager1v1Tank._id === '') {
-					toast.error('Tank not loaded yet, select it again.');
-					return;
-				}
 				if (stipendApplied) {
 					toast.success('$100 added for setting your daily wager!');
 				}
@@ -179,11 +168,10 @@ class SetWagerPopup extends React.Component<Props, State> {
 	}
 
 	// Updates newWager3v3Tanks when changing a tank.
-	update3v3Tanks(newTankId: string, tankIndex: number): void {
-		const newTank: Tank = this.state.allTanks[this.state.allTanks.findIndex(tank => tank._id === newTankId)];
-		let newWager3v3Tanks: Array<?Tank> = this.state.newWager3v3Tanks;
-		newWager3v3Tanks[tankIndex] = newTank;
-		this.setState({newWager3v3Tanks: newWager3v3Tanks});
+	update3v3Tanks(newTank: ?Tank, tankIndex: number): void {
+		let newWagerTanks: Array<?Tank> = this.state.newWager3v3Tanks;
+		newWagerTanks[tankIndex] = newTank;
+		this.setState({newWager3v3Tanks: newWagerTanks});
 	}
 
 	render(): React.Node {
@@ -278,62 +266,38 @@ class SetWagerPopup extends React.Component<Props, State> {
 							<h5>Select Tank{this.state.battleType === '1 vs 1' ? '' : 's'}</h5>
 							{this.state.battleType === '1 vs 1' ?
 								<div>
-									<select 
-										className="dropdownMenu"
-										onChange={(e) => this.setState({newWager1v1Tank: this.state.allTanks[this.state.allTanks.findIndex(tank => tank._id === e.target.value)]})}
-									>
-										{this.state.allTanks.map((tank, index) => 
-											<option key={index} value={tank._id}>
-												{tank.tankName}
-											</option>
-										)}
-									</select>
+									<SelectTank
+										allTanks={this.state.allTanks}
+										propogateChangesToCasus={false}
+										changeSelectedTank={(tank) => this.setState({newWager1v1Tank: tank})}
+										selectedTank={this.state.newWager1v1Tank}
+										allowRemoveTank={false}
+									/>
 								</div> : 
 								<div>
-									<select 
-										className="dropdownMenu"
-										onChange={(e) => this.update3v3Tanks(e.target.value, 0)}
-									>
-										<option value={null}>No Tank</option>
-										{this.state.allTanks
-											.filter(tank => tank !== this.state.newWager3v3Tanks[1] && tank !== this.state.newWager3v3Tanks[2])
-											.map((tank, index) => 
-												<option key={index} value={tank._id}>
-													{tank.tankName}
-												</option>
-											)
-										}
-									</select>
+									<SelectTank
+										allTanks={this.state.allTanks.filter(tank => tank !== this.state.newWager3v3Tanks[1] && tank !== this.state.newWager3v3Tanks[2])}
+										propogateChangesToCasus={false}
+										changeSelectedTank={(tank) => this.update3v3Tanks(tank, 0)}
+										selectedTank={this.state.newWager3v3Tanks[0]}
+										allowRemoveTank={true}
+									/>
 									<br/>
-									<select 
-										className="dropdownMenu"
-										onChange={(e) => this.update3v3Tanks(e.target.value, 1)}
-									>
-										<option value={null}>No Tank</option>
-										{this.state.allTanks
-											.filter(tank => tank !== this.state.newWager3v3Tanks[0] && tank !== this.state.newWager3v3Tanks[2])
-											.map((tank, index) => 
-												<option key={index} value={tank._id}>
-													{tank.tankName}
-												</option>
-											)
-										}
-									</select>
+									<SelectTank
+										allTanks={this.state.allTanks.filter(tank => tank !== this.state.newWager3v3Tanks[0] && tank !== this.state.newWager3v3Tanks[2])}
+										propogateChangesToCasus={false}
+										changeSelectedTank={(tank) => this.update3v3Tanks(tank, 1)}
+										selectedTank={this.state.newWager3v3Tanks[1]}
+										allowRemoveTank={true}
+									/>
 									<br/>
-									<select 
-										className="dropdownMenu"
-										onChange={(e) => this.update3v3Tanks(e.target.value, 2)}
-									>
-										<option value={null}>No Tank</option>
-										{this.state.allTanks
-											.filter(tank => tank !== this.state.newWager3v3Tanks[0] && tank !== this.state.newWager3v3Tanks[1])
-											.map((tank, index) => 
-												<option key={index} value={tank._id}>
-													{tank.tankName}
-												</option>
-											)
-										}
-									</select>
+									<SelectTank
+										allTanks={this.state.allTanks.filter(tank => tank !== this.state.newWager3v3Tanks[0] && tank !== this.state.newWager3v3Tanks[1])}
+										propogateChangesToCasus={false}
+										changeSelectedTank={(tank) => this.update3v3Tanks(tank, 2)}
+										selectedTank={this.state.newWager3v3Tanks[2]}
+										allowRemoveTank={true}
+									/>
 								</div>
 							}
 							<br/>

--- a/src/armory/SetWagerPopup.js
+++ b/src/armory/SetWagerPopup.js
@@ -109,7 +109,8 @@ class SetWagerPopup extends React.Component<Props, State> {
 
 		// Set the new wager and favorite tank depending on the battleType.
 		if (this.state.battleType === '1 vs 1') {
-			if (this.state.newWager1v1Tank == null) {
+			const tankToWager=this.state.newWager1v1Tank;
+			if (tankToWager == null) {
 				toast.error('No set wager tank!');
 				return;
 			}
@@ -121,7 +122,7 @@ class SetWagerPopup extends React.Component<Props, State> {
 				// Update user currency in the navbar.
 				this.props.onWagerUpdate();
 			});
-			setFavoriteTankId(this.state.newWager1v1Tank._id, () => {
+			setFavoriteTankId(tankToWager._id, () => {
 				this.setState({setWagerOpen: false, userWager1v1Tank: this.state.newWager1v1Tank});
 			});
 		}

--- a/src/battlearena/BattleArena.js
+++ b/src/battlearena/BattleArena.js
@@ -134,6 +134,7 @@ class BattleArena extends React.Component<Props, State> {
 							allTanks={this.state.allTanks}
 							changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
 							propogateChangesToCasus={true}
+							allowRemoveTank={false}
 						/>
 						{this.state.selectedTankOne == null ? <div className="emptyTankBig"></div> : <TankDisplay tankToDisplay={this.state.selectedTankOne} smallTank={false} />}
 					</div> :
@@ -147,6 +148,7 @@ class BattleArena extends React.Component<Props, State> {
 											allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankThree)}
 											changeSelectedTank={(tank) => this.setState({selectedTankTwo: tank})}
 											propogateChangesToCasus={false}
+											allowRemoveTank={true}
 										/>
 									</th>
 									<th>
@@ -155,6 +157,7 @@ class BattleArena extends React.Component<Props, State> {
 											allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankThree && tank !== this.state.selectedTankTwo)}
 											changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
 											propogateChangesToCasus={false}
+											allowRemoveTank={true}
 										/>
 									</th>
 									<th>
@@ -163,6 +166,7 @@ class BattleArena extends React.Component<Props, State> {
 											allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankTwo)}
 											changeSelectedTank={(tank) => this.setState({selectedTankThree: tank})}
 											propogateChangesToCasus={false}
+											allowRemoveTank={true}
 										/>
 									</th>
 								</tr>

--- a/src/globalComponents/SelectTank.js
+++ b/src/globalComponents/SelectTank.js
@@ -9,6 +9,7 @@ type Props = {|
 	changeSelectedTank: (?Tank) => void,
 	selectedTank: ?Tank,
 	propogateChangesToCasus: boolean,
+	allowRemoveTank: boolean
 |};
 
 type State = {|
@@ -71,10 +72,11 @@ class SelectTank extends React.Component<Props, State> {
 									<br/>
 								</div>
 							)}
-							{window.location.pathname === '/Armory' ? <div></div> :
+							{this.props.allowRemoveTank ?
 								<button className="removeTankBtn" onClick={() => this.onChangeSelectedTank(null)}>
 									Remove Tank
-								</button>
+								</button> :
+								<div></div>
 							}
 						</div> :
 						<div></div>

--- a/src/trainingarena/TrainingArena.js
+++ b/src/trainingarena/TrainingArena.js
@@ -136,6 +136,7 @@ class TrainingArena extends React.Component<Props, State> {
 								allTanks={this.state.allTanks}
 								changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
 								propogateChangesToCasus={true}
+								allowRemoveTank={false}
 							/>
 							{this.state.selectedTankOne == null ? <div className="emptyTankBig"></div> : <TankDisplay tankToDisplay={this.state.selectedTankOne} smallTank={false} />}
 						</div> :
@@ -149,6 +150,7 @@ class TrainingArena extends React.Component<Props, State> {
 												allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankThree)}
 												changeSelectedTank={(tank) => this.setState({selectedTankTwo: tank})}
 												propogateChangesToCasus={false}
+												allowRemoveTank={true}
 											/>
 										</th>
 										<th>
@@ -157,6 +159,7 @@ class TrainingArena extends React.Component<Props, State> {
 												allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankThree && tank !== this.state.selectedTankTwo)}
 												changeSelectedTank={(tank) => this.setState({selectedTankOne: tank})}
 												propogateChangesToCasus={false}
+												allowRemoveTank={true}
 											/>
 										</th>
 										<th>
@@ -165,6 +168,7 @@ class TrainingArena extends React.Component<Props, State> {
 												allTanks={this.state.allTanks.filter(tank => tank !== this.state.selectedTankOne && tank !== this.state.selectedTankTwo)}
 												changeSelectedTank={(tank) => this.setState({selectedTankThree: tank})}
 												propogateChangesToCasus={false}
+												allowRemoveTank={true}
 											/>
 										</th>
 									</tr>
@@ -242,6 +246,7 @@ class TrainingArena extends React.Component<Props, State> {
 								allTanks={this.state.botTanks}
 								changeSelectedTank={(tank) => this.setState({botTankOne: tank})}
 								propogateChangesToCasus={false}
+								allowRemoveTank={false}
 							/>
 							{this.state.botTankOne == null ? <div className="emptyTankBig"></div> : <TankDisplay tankToDisplay={this.state.botTankOne} smallTank={false} />}
 						</div> :
@@ -255,6 +260,7 @@ class TrainingArena extends React.Component<Props, State> {
 												allTanks={this.state.botTanks}
 												changeSelectedTank={(tank) => this.setState({botTankTwo: tank})}
 												propogateChangesToCasus={false}
+												allowRemoveTank={true}
 											/>
 										</th>
 										<th>
@@ -263,6 +269,7 @@ class TrainingArena extends React.Component<Props, State> {
 												allTanks={this.state.botTanks}
 												changeSelectedTank={(tank) => this.setState({botTankOne: tank})}
 												propogateChangesToCasus={false}
+												allowRemoveTank={true}
 											/>
 										</th>
 										<th>
@@ -271,6 +278,7 @@ class TrainingArena extends React.Component<Props, State> {
 												allTanks={this.state.botTanks}
 												changeSelectedTank={(tank) => this.setState({botTankThree: tank})}
 												propogateChangesToCasus={false}
+												allowRemoveTank={true}
 											/>
 										</th>
 									</tr>


### PR DESCRIPTION
**Description**
To avoid some wonky dropdown menu errors, I used SelectTank menus for setting up wagers. It is much cleaner now. Also, I set a new props to select tank called allowRemoveTank. Set this to true if you want the user to be able to set no tank.

**Resolves These Issues**
None were set.

**Type of change**
Check options that are relevant.

- [x] Bug fix (fixes a bug issue)
- [ ] New feature (adds functionality)
- [ ] This fix or feature will cause existing functionality to not work as expected. (Please elaborate in Description.)

**Steps to Verify Functionality**
1. Go to Armory.
2. Make a 1v1 and 3v3 wager.
3. Ensure switching your tanks in the wagers causes no issues.
4. Check backend values for wagers match the frontend values.
5. Remove wagers.

**Final Checklist:**
Go down the list and check them off.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code
- [x] My changes pass Flow, build without errors and (if applicable) pass Jest tests.
- [ ] This change requires a update in the design document (if applicable)